### PR TITLE
Use async_forward_entry_setups instead of async_setup_platforms, update pytest

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.10"]
 
     steps:
       - uses: actions/checkout@v3
@@ -23,10 +23,10 @@ jobs:
         run: |
 
           python -m pip install --upgrade pip
-          pip install -r requirements_test.txt
+          pip install --upgrade -r requirements_test.txt
       - name: Generate coverage report
         run: |
-          python -m pytest
+          python -m pytest --asyncio-mode=auto
           pip install pytest-cov
           pytest ./tests/ --cov=custom_components/teamtracker/ --cov-report=xml
       - name: Upload coverage to Codecov

--- a/custom_components/teamtracker/__init__.py
+++ b/custom_components/teamtracker/__init__.py
@@ -97,7 +97,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         COORDINATOR: coordinator,
     }
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,7 @@
 black
 isort
 pytest
+pytest-asyncio
 pytest-cov
 pytest-mock
 pytest-homeassistant-custom-component

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,8 @@
 """Fixtures for tests"""
+import asyncio
 import pytest
 
-pytest_plugins = "pytest_homeassistant_custom_component"
+pytest_plugins = ("pytest_homeassistant_custom_component", "pytest_asyncio")
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
- Use async_forward_entry_setups function instead of async_setup_platforms

* Use of async_setup_platforms will result in the integration failing to start as of Home Assistant 2023.3