### PR TITLE
Improve config validation and some cleanup

### DIFF
--- a/custom_components/teamtracker/const.py
+++ b/custom_components/teamtracker/const.py
@@ -98,10 +98,8 @@ DEFAULT_LEAGUE = "NFL"
 DEFAULT_LOGO = (
     "https://cdn0.iconfinder.com/data/icons/shift-interfaces/32/Error-512.png"
 )
-DEFAULT_LEAGUE_PATH = "league_not_found"
 DEFAULT_NAME = "team_tracker"
 DEFAULT_PROB = 0.0
-DEFAULT_SPORT_PATH = "sport_not_found"
 DEFAULT_TIMEOUT = 120
 DEFAULT_LAST_UPDATE = "2022-02-02 02:02:02-05:00"
 DEFAULT_KICKOFF_IN = "{test} days"

--- a/custom_components/teamtracker/const.py
+++ b/custom_components/teamtracker/const.py
@@ -34,10 +34,22 @@ VOLLEYBALL = "volleyball"
 
 # Maps
 LEAGUE_MAP = {
-    "AFL": {CONF_SPORT_PATH: AUSTRALIAN_FOOTBALL, CONF_LEAGUE_PATH: "afl"},
-    "MLB": {CONF_SPORT_PATH: BASEBALL, CONF_LEAGUE_PATH: "mlb"},
-    "NBA": {CONF_SPORT_PATH: BASKETBALL, CONF_LEAGUE_PATH: "nba"},
-    "WNBA": {CONF_SPORT_PATH: BASKETBALL, CONF_LEAGUE_PATH: "wnba"},
+    "AFL": {
+        CONF_SPORT_PATH: AUSTRALIAN_FOOTBALL,
+        CONF_LEAGUE_PATH: "afl",
+    },
+    "MLB": {
+        CONF_SPORT_PATH: BASEBALL,
+        CONF_LEAGUE_PATH: "mlb",
+    },
+    "NBA": {
+        CONF_SPORT_PATH: BASKETBALL,
+        CONF_LEAGUE_PATH: "nba",
+    },
+    "WNBA": {
+        CONF_SPORT_PATH: BASKETBALL,
+        CONF_LEAGUE_PATH: "wnba",
+    },
     "NCAAM": {
         CONF_SPORT_PATH: BASKETBALL,
         CONF_LEAGUE_PATH: "mens-college-basketball",
@@ -46,25 +58,82 @@ LEAGUE_MAP = {
         CONF_SPORT_PATH: BASKETBALL,
         CONF_LEAGUE_PATH: "womens-college-basketball",
     },
-    "NCAAF": {CONF_SPORT_PATH: FOOTBALL, CONF_LEAGUE_PATH: "college-football"},
-    "NFL": {CONF_SPORT_PATH: FOOTBALL, CONF_LEAGUE_PATH: "nfl"},
-    "PGA": {CONF_SPORT_PATH: GOLF, CONF_LEAGUE_PATH: "pga"},
-    "NHL": {CONF_SPORT_PATH: HOCKEY, CONF_LEAGUE_PATH: "nhl"},
-    "UFC": {CONF_SPORT_PATH: MMA, CONF_LEAGUE_PATH: "ufc"},
-    "F1": {CONF_SPORT_PATH: RACING, CONF_LEAGUE_PATH: "f1"},
-    "IRL": {CONF_SPORT_PATH: RACING, CONF_LEAGUE_PATH: "irl"},
-    "NASCAR": {CONF_SPORT_PATH: RACING, CONF_LEAGUE_PATH: "nascar-premier"},
-    "BUND": {CONF_SPORT_PATH: SOCCER, CONF_LEAGUE_PATH: "ger.1"},
-    "CL": {CONF_SPORT_PATH: SOCCER, CONF_LEAGUE_PATH: "uefa.champions"},
-    "EPL": {CONF_SPORT_PATH: SOCCER, CONF_LEAGUE_PATH: "eng.1"},
-    "LIGA": {CONF_SPORT_PATH: SOCCER, CONF_LEAGUE_PATH: "esp.1"},
-    "LIG1": {CONF_SPORT_PATH: SOCCER, CONF_LEAGUE_PATH: "fra.1"},
-    "MLS": {CONF_SPORT_PATH: SOCCER, CONF_LEAGUE_PATH: "usa.1"},
-    "NWSL": {CONF_SPORT_PATH: SOCCER, CONF_LEAGUE_PATH: "usa.nwsl"},
-    "SERA": {CONF_SPORT_PATH: SOCCER, CONF_LEAGUE_PATH: "ita.1"},
-    "WC": {CONF_SPORT_PATH: SOCCER, CONF_LEAGUE_PATH: "fifa.world"},
-    "ATP": {CONF_SPORT_PATH: TENNIS, CONF_LEAGUE_PATH: "atp"},
-    "WTA": {CONF_SPORT_PATH: TENNIS, CONF_LEAGUE_PATH: "wta"},
+    "NCAAF": {
+        CONF_SPORT_PATH: FOOTBALL,
+        CONF_LEAGUE_PATH: "college-football",
+    },
+    "NFL": {
+        CONF_SPORT_PATH: FOOTBALL,
+        CONF_LEAGUE_PATH: "nfl",
+    },
+    "PGA": {
+        CONF_SPORT_PATH: GOLF,
+        CONF_LEAGUE_PATH: "pga",
+    },
+    "NHL": {
+        CONF_SPORT_PATH: HOCKEY,
+        CONF_LEAGUE_PATH: "nhl",
+    },
+    "UFC": {
+        CONF_SPORT_PATH: MMA,
+        CONF_LEAGUE_PATH: "ufc",
+    },
+    "F1": {
+        CONF_SPORT_PATH: RACING,
+        CONF_LEAGUE_PATH: "f1",
+    },
+    "IRL": {
+        CONF_SPORT_PATH: RACING,
+        CONF_LEAGUE_PATH: "irl",
+    },
+    "NASCAR": {
+        CONF_SPORT_PATH: RACING,
+        CONF_LEAGUE_PATH: "nascar-premier",
+    },
+    "BUND": {
+        CONF_SPORT_PATH: SOCCER,
+        CONF_LEAGUE_PATH: "ger.1",
+    },
+    "CL": {
+        CONF_SPORT_PATH: SOCCER,
+        CONF_LEAGUE_PATH: "uefa.champions",
+    },
+    "EPL": {
+        CONF_SPORT_PATH: SOCCER,
+        CONF_LEAGUE_PATH: "eng.1",
+    },
+    "LIGA": {
+        CONF_SPORT_PATH: SOCCER,
+        CONF_LEAGUE_PATH: "esp.1",
+    },
+    "LIG1": {
+        CONF_SPORT_PATH: SOCCER,
+        CONF_LEAGUE_PATH: "fra.1",
+    },
+    "MLS": {
+        CONF_SPORT_PATH: SOCCER,
+        CONF_LEAGUE_PATH: "usa.1",
+    },
+    "NWSL": {
+        CONF_SPORT_PATH: SOCCER,
+        CONF_LEAGUE_PATH: "usa.nwsl",
+    },
+    "SERA": {
+        CONF_SPORT_PATH: SOCCER,
+        CONF_LEAGUE_PATH: "ita.1",
+    },
+    "WC": {
+        CONF_SPORT_PATH: SOCCER,
+        CONF_LEAGUE_PATH: "fifa.world",
+    },
+    "ATP": {
+        CONF_SPORT_PATH: TENNIS,
+        CONF_LEAGUE_PATH: "atp",
+    },
+    "WTA": {
+        CONF_SPORT_PATH: TENNIS,
+        CONF_LEAGUE_PATH: "wta",
+    },
     "NCAAVB": {
         CONF_SPORT_PATH: VOLLEYBALL,
         CONF_LEAGUE_PATH: "mens-college-volleyball",

--- a/custom_components/teamtracker/const.py
+++ b/custom_components/teamtracker/const.py
@@ -1,4 +1,5 @@
 """ Constants for teamtracker sensor"""
+from homeassistant.const import Platform
 
 # API
 URL_HEAD = "http://site.api.espn.com/apis/site/v2/sports/"
@@ -178,7 +179,6 @@ TEAM_ID = ""
 VERSION = "v0.7.4"
 ISSUE_URL = "https://github.com/vasqued2/ha-teamtracker"
 DOMAIN = "teamtracker"
-PLATFORM = "sensor"
 ATTRIBUTION = "Data provided by ESPN"
 COORDINATOR = "coordinator"
-PLATFORMS = ["sensor"]
+PLATFORMS = [Platform.SENSOR]

--- a/custom_components/teamtracker/const.py
+++ b/custom_components/teamtracker/const.py
@@ -4,53 +4,10 @@
 URL_HEAD = "http://site.api.espn.com/apis/site/v2/sports/"
 URL_TAIL = "/scoreboard"
 API_LIMIT = 25
-USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Safari/605.1.15"
-
-LEAGUE_LIST = [
-    ["AFL", "australian-football", "afl"],
-    ["MLB", "baseball", "mlb"],
-    ["NBA", "basketball", "nba"],
-    ["WNBA", "basketball", "wnba"],
-    ["NCAAM", "basketball", "mens-college-basketball"],
-    ["NCAAW", "basketball", "womens-college-basketball"],
-    ["NCAAF", "football", "college-football"],
-    ["NFL", "football", "nfl"],
-    ["PGA", "golf", "pga"],
-    ["NHL", "hockey", "nhl"],
-    ["UFC", "mma", "ufc"],
-    ["F1", "racing", "f1"],
-    ["IRL", "racing", "irl"],
-    ["NASCAR", "racing", "nascar-premier"],
-    ["BUND", "soccer", "ger.1"],
-    ["CL", "soccer", "uefa.champions"],
-    ["EPL", "soccer", "eng.1"],
-    ["LIGA", "soccer", "esp.1"],
-    ["LIG1", "soccer", "fra.1"],
-    ["MLS", "soccer", "usa.1"],
-    ["NWSL", "soccer", "usa.nwsl"],
-    ["SERA", "soccer", "ita.1"],
-    ["WC", "soccer", "fifa.world"],
-    ["ATP", "tennis", "atp"],
-    ["WTA", "tennis", "wta"],
-    ["NCAAVB", "volleyball", "mens-college-volleyball"],
-    ["NCAAVBW", "volleyball", "womens-college-volleyball"],
-]
-
-SPORT_LIST = [
-    ["australian-football", "mdi:football-australian"],
-    ["baseball", "mdi:baseball"],
-    ["basketball", "mdi:basketball"],
-    ["cricket", "mdi:cricket"],
-    ["football", "mdi:football"],
-    ["golf", "mdi:golf-tee"],
-    ["hockey", "mdi:hockey-puck"],
-    ["mma", "mdi:karate"],
-    ["racing", "mdi:flag-checkered"],
-    ["rugby", "mdi:rugby"],
-    ["soccer", "mdi:soccer"],
-    ["tennis", "mdi:tennis"],
-    ["volleyball", "mdi:volleyball"],
-]
+USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_6) AppleWebKit/605.1.15 (KHTML, like "
+    "Gecko) Version/15.0 Safari/605.1.15"
+)
 
 # Config
 CONF_CONFERENCE_ID = "conference_id"
@@ -59,6 +16,80 @@ CONF_LEAGUE_PATH = "league_path"
 CONF_SPORT_PATH = "sport_path"
 CONF_TIMEOUT = "timeout"
 CONF_TEAM_ID = "team_id"
+
+# Sports
+AUSTRALIAN_FOOTBALL = "australian-football"
+BASEBALL = "baseball"
+BASKETBALL = "basketball"
+CRICKET = "cricket"
+FOOTBALL = "football"
+GOLF = "golf"
+HOCKEY = "hockey"
+MMA = "mma"
+RACING = "racing"
+RUGBY = "rugby"
+SOCCER = "soccer"
+TENNIS = "tennis"
+VOLLEYBALL = "volleyball"
+
+# Maps
+LEAGUE_MAP = {
+    "AFL": {CONF_SPORT_PATH: AUSTRALIAN_FOOTBALL, CONF_LEAGUE_PATH: "afl"},
+    "MLB": {CONF_SPORT_PATH: BASEBALL, CONF_LEAGUE_PATH: "mlb"},
+    "NBA": {CONF_SPORT_PATH: BASKETBALL, CONF_LEAGUE_PATH: "nba"},
+    "WNBA": {CONF_SPORT_PATH: BASKETBALL, CONF_LEAGUE_PATH: "wnba"},
+    "NCAAM": {
+        CONF_SPORT_PATH: BASKETBALL,
+        CONF_LEAGUE_PATH: "mens-college-basketball",
+    },
+    "NCAAW": {
+        CONF_SPORT_PATH: BASKETBALL,
+        CONF_LEAGUE_PATH: "womens-college-basketball",
+    },
+    "NCAAF": {CONF_SPORT_PATH: FOOTBALL, CONF_LEAGUE_PATH: "college-football"},
+    "NFL": {CONF_SPORT_PATH: FOOTBALL, CONF_LEAGUE_PATH: "nfl"},
+    "PGA": {CONF_SPORT_PATH: GOLF, CONF_LEAGUE_PATH: "pga"},
+    "NHL": {CONF_SPORT_PATH: HOCKEY, CONF_LEAGUE_PATH: "nhl"},
+    "UFC": {CONF_SPORT_PATH: MMA, CONF_LEAGUE_PATH: "ufc"},
+    "F1": {CONF_SPORT_PATH: RACING, CONF_LEAGUE_PATH: "f1"},
+    "IRL": {CONF_SPORT_PATH: RACING, CONF_LEAGUE_PATH: "irl"},
+    "NASCAR": {CONF_SPORT_PATH: RACING, CONF_LEAGUE_PATH: "nascar-premier"},
+    "BUND": {CONF_SPORT_PATH: SOCCER, CONF_LEAGUE_PATH: "ger.1"},
+    "CL": {CONF_SPORT_PATH: SOCCER, CONF_LEAGUE_PATH: "uefa.champions"},
+    "EPL": {CONF_SPORT_PATH: SOCCER, CONF_LEAGUE_PATH: "eng.1"},
+    "LIGA": {CONF_SPORT_PATH: SOCCER, CONF_LEAGUE_PATH: "esp.1"},
+    "LIG1": {CONF_SPORT_PATH: SOCCER, CONF_LEAGUE_PATH: "fra.1"},
+    "MLS": {CONF_SPORT_PATH: SOCCER, CONF_LEAGUE_PATH: "usa.1"},
+    "NWSL": {CONF_SPORT_PATH: SOCCER, CONF_LEAGUE_PATH: "usa.nwsl"},
+    "SERA": {CONF_SPORT_PATH: SOCCER, CONF_LEAGUE_PATH: "ita.1"},
+    "WC": {CONF_SPORT_PATH: SOCCER, CONF_LEAGUE_PATH: "fifa.world"},
+    "ATP": {CONF_SPORT_PATH: TENNIS, CONF_LEAGUE_PATH: "atp"},
+    "WTA": {CONF_SPORT_PATH: TENNIS, CONF_LEAGUE_PATH: "wta"},
+    "NCAAVB": {
+        CONF_SPORT_PATH: VOLLEYBALL,
+        CONF_LEAGUE_PATH: "mens-college-volleyball",
+    },
+    "NCAAVBW": {
+        CONF_SPORT_PATH: VOLLEYBALL,
+        CONF_LEAGUE_PATH: "womens-college-volleyball",
+    },
+}
+
+SPORT_ICON_MAP = {
+    AUSTRALIAN_FOOTBALL: "mdi:football-australian",
+    BASEBALL: "mdi:baseball",
+    BASKETBALL: "mdi:basketball",
+    CRICKET: "mdi:cricket",
+    FOOTBALL: "mdi:football",
+    GOLF: "mdi:golf-tee",
+    HOCKEY: "mdi:hockey-puck",
+    MMA: "mdi:karate",
+    RACING: "mdi:flag-checkered",
+    RUGBY: "mdi:rugby",
+    SOCCER: "mdi:soccer",
+    TENNIS: "mdi:tennis",
+    VOLLEYBALL: "mdi:volleyball",
+}
 
 # Defaults
 DEFAULT_CONFERENCE_ID = ""

--- a/custom_components/teamtracker/event.py
+++ b/custom_components/teamtracker/event.py
@@ -48,7 +48,9 @@ async def async_process_event(
             competition_date_str = await async_get_value(
                 competition, "date", default=(await async_get_value(event, "date"))
             )
-            competition_date = datetime.strptime(competition_date_str, "%Y-%m-%dT%H:%Mz")
+            competition_date = datetime.strptime(
+                competition_date_str, "%Y-%m-%dT%H:%Mz"
+            )
             if competition_date > last_date:
                 last_date = competition_date
             if competition_date < first_date:
@@ -67,7 +69,7 @@ async def async_process_event(
                     competition,
                     competitor,
                     team_index,
-                    sport_path
+                    sport_path,
                 )
 
                 if matched_index is not None:
@@ -171,11 +173,20 @@ async def async_process_event(
 
 
 async def async_find_search_key(
-    values, sensor_name, search_key, event, competition, competitor, team_index, sport_path
+    values,
+    sensor_name,
+    search_key,
+    event,
+    competition,
+    competitor,
+    team_index,
+    sport_path,
 ):
     """Check if there is a match on wildcard, team_abbreviation, event_name, or athlete_name"""
 
-    if search_key == "*" and (competitor["type"] == "athlete" or sport_path not in ["tennis", "golf"]):
+    if search_key == "*" and (
+        competitor["type"] == "athlete" or sport_path not in ["tennis", "golf"]
+    ):
         _LOGGER.debug(
             "%s: Found competitor using wildcard '%s'; parsing data.",
             sensor_name,

--- a/custom_components/teamtracker/sensor.py
+++ b/custom_components/teamtracker/sensor.py
@@ -70,8 +70,10 @@ async def async_setup_platform(
         error_msg = (
             "Must specify sport and league path for custom league (league_id = XXX)"
         )
-        _LOGGER.error(error_msg)
-        async_create(hass, f"Error: {error_msg}", "Team Tracker", DOMAIN)
+        _LOGGER.error("%s: %s", config[CONF_NAME], error_msg)
+        async_create(
+            hass, f"{config[CONF_NAME]} Error: {error_msg}", "Team Tracker", DOMAIN
+        )
         return
 
     league_id = config[CONF_LEAGUE_ID].upper()

--- a/custom_components/teamtracker/sensor.py
+++ b/custom_components/teamtracker/sensor.py
@@ -1,6 +1,6 @@
 """ Home Assistant sensor processing """
-
 import logging
+from typing import Any
 
 import voluptuous as vol
 
@@ -10,7 +10,9 @@ from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import slugify
 
 from . import TeamTrackerDataUpdateCoordinator
@@ -50,7 +52,12 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info=None,
+) -> None:
     """Configuration from yaml"""
 
     _LOGGER.debug("%s: Setting up sensor from YAML", config[CONF_NAME])
@@ -102,7 +109,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     async_add_entities([TeamTrackerScoresSensor(hass, config)], True)
 
 
-async def async_setup_entry(hass, entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
     """Setup the sensor platform."""
     async_add_entities([TeamTrackerScoresSensor(hass, entry)], True)
 
@@ -191,24 +200,24 @@ class TeamTrackerScoresSensor(CoordinatorEntity):
         self._api_message = None
 
     @property
-    def unique_id(self):
+    def unique_id(self) -> str:
         """
         Return a unique, Home Assistant friendly identifier for this entity.
         """
         return f"{slugify(self._name)}_{self._config.entry_id}"
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the name of the sensor."""
         return self._name
 
     @property
-    def icon(self):
+    def icon(self) -> str:
         """Return the icon to use in the frontend, if any."""
         return self._icon
 
     @property
-    def state(self):
+    def state(self) -> str:
         """Return the state of the sensor."""
         if self.coordinator.data is None:
             return None
@@ -219,7 +228,7 @@ class TeamTrackerScoresSensor(CoordinatorEntity):
         return None
 
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state message."""
         attrs = {}
 

--- a/custom_components/teamtracker/sensor.py
+++ b/custom_components/teamtracker/sensor.py
@@ -39,9 +39,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Required(CONF_LEAGUE_ID, default=DEFAULT_LEAGUE): vol.All(
-            vol.Upper, vol.In([*LEAGUE_MAP.keys(), "XXX"])
-        ),
+        vol.Required(CONF_LEAGUE_ID, default=DEFAULT_LEAGUE): vol.Upper,
         vol.Required(CONF_TEAM_ID): cv.string,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): int,
@@ -61,6 +59,8 @@ async def async_setup_platform(
     """Configuration from yaml"""
 
     _LOGGER.debug("%s: Setting up sensor from YAML", config[CONF_NAME])
+
+    vol.In([*LEAGUE_MAP.keys(), "XXX"])(config[CONF_LEAGUE_ID])
 
     # Raise an exception if the league ID is XXX and the sport or league path is not
     # specified

--- a/custom_components/teamtracker/sensor.py
+++ b/custom_components/teamtracker/sensor.py
@@ -4,11 +4,11 @@ from typing import Any
 
 import voluptuous as vol
 
+from homeassistant.components.persistent_notification import async_create
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -67,9 +67,12 @@ async def async_setup_platform(
     if config[CONF_LEAGUE_ID] == "XXX" and not (
         CONF_SPORT_PATH in config and CONF_LEAGUE_PATH in config
     ):
-        raise PlatformNotReady(
+        error_msg = (
             "Must specify sport and league path for custom league (league_id = XXX)"
         )
+        _LOGGER.error(error_msg)
+        async_create(hass, f"Error: {error_msg}", "Team Tracker", DOMAIN)
+        return
 
     league_id = config[CONF_LEAGUE_ID].upper()
     # If the league ID is not in the map, it must be XXX and therefore we get the path

--- a/custom_components/teamtracker/sensor.py
+++ b/custom_components/teamtracker/sensor.py
@@ -39,8 +39,8 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Required(CONF_LEAGUE_ID, default=DEFAULT_LEAGUE): vol.In(
-            [*LEAGUE_MAP, "XXX"]
+        vol.Required(CONF_LEAGUE_ID, default=DEFAULT_LEAGUE): vol.All(
+            vol.Upper, vol.In([*LEAGUE_MAP, "XXX"])
         ),
         vol.Required(CONF_TEAM_ID): cv.string,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,

--- a/custom_components/teamtracker/sensor.py
+++ b/custom_components/teamtracker/sensor.py
@@ -65,9 +65,7 @@ async def async_setup_platform(
     try:
         vol.In(league_ids)(config[CONF_LEAGUE_ID])
     except vol.Invalid:
-        _LOGGER.error(
-            "%s: `league_id` must be valid (one of %s)", name, league_ids
-        )
+        _LOGGER.error("%s: `league_id` must be valid (one of %s)", name, league_ids)
         async_create(
             hass,
             f"{name} Error: `league_id` must be valid (one of {league_ids})",
@@ -85,9 +83,7 @@ async def async_setup_platform(
             "Must specify sport and league path for custom league (league_id = XXX)"
         )
         _LOGGER.error("%s: %s", name, error_msg)
-        async_create(
-            hass, f"{name} Error: {error_msg}", "Team Tracker", DOMAIN
-        )
+        async_create(hass, f"{name} Error: {error_msg}", "Team Tracker", DOMAIN)
         return
 
     league_id = config[CONF_LEAGUE_ID].upper()

--- a/custom_components/teamtracker/sensor.py
+++ b/custom_components/teamtracker/sensor.py
@@ -57,18 +57,22 @@ async def async_setup_platform(
     discovery_info=None,
 ) -> None:
     """Configuration from yaml"""
+    name = config[CONF_NAME]
 
-    _LOGGER.debug("%s: Setting up sensor from YAML", config[CONF_NAME])
+    _LOGGER.debug("%s: Setting up sensor from YAML", name)
 
     league_ids = [*LEAGUE_MAP.keys(), "XXX"]
-    error_msg = f"`league_id` must be one of the following values: {league_ids}"
-
     try:
         vol.In(league_ids)(config[CONF_LEAGUE_ID])
     except vol.Invalid:
-        _LOGGER.error("%s: %s", config[CONF_NAME], error_msg)
+        _LOGGER.error(
+            "%s: `league_id` must be valid (one of %s)", name, league_ids
+        )
         async_create(
-            hass, f"{config[CONF_NAME]} Error: {error_msg}", "Team Tracker", DOMAIN
+            hass,
+            f"{name} Error: `league_id` must be valid (one of {league_ids})",
+            "Team Tracker",
+            DOMAIN,
         )
         return
 
@@ -80,9 +84,9 @@ async def async_setup_platform(
         error_msg = (
             "Must specify sport and league path for custom league (league_id = XXX)"
         )
-        _LOGGER.error("%s: %s", config[CONF_NAME], error_msg)
+        _LOGGER.error("%s: %s", name, error_msg)
         async_create(
-            hass, f"{config[CONF_NAME]} Error: {error_msg}", "Team Tracker", DOMAIN
+            hass, f"{name} Error: {error_msg}", "Team Tracker", DOMAIN
         )
         return
 

--- a/custom_components/teamtracker/sensor.py
+++ b/custom_components/teamtracker/sensor.py
@@ -40,7 +40,7 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_LEAGUE_ID, default=DEFAULT_LEAGUE): vol.All(
-            vol.Upper, vol.In([*LEAGUE_MAP, "XXX"])
+            vol.Upper, vol.In([*LEAGUE_MAP.keys(), "XXX"])
         ),
         vol.Required(CONF_TEAM_ID): cv.string,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,

--- a/custom_components/teamtracker/sensor.py
+++ b/custom_components/teamtracker/sensor.py
@@ -60,7 +60,17 @@ async def async_setup_platform(
 
     _LOGGER.debug("%s: Setting up sensor from YAML", config[CONF_NAME])
 
-    vol.In([*LEAGUE_MAP.keys(), "XXX"])(config[CONF_LEAGUE_ID])
+    league_ids = [*LEAGUE_MAP.keys(), "XXX"]
+    error_msg = f"`league_id` must be one of the following values: {league_ids}"
+
+    try:
+        vol.In(league_ids)(config[CONF_LEAGUE_ID])
+    except vol.Invalid:
+        _LOGGER.error("%s: %s", config[CONF_NAME], error_msg)
+        async_create(
+            hass, f"{config[CONF_NAME]} Error: {error_msg}", "Team Tracker", DOMAIN
+        )
+        return
 
     # Raise an exception if the league ID is XXX and the sport or league path is not
     # specified


### PR DESCRIPTION
Went a little overboard here so tell me if you want me to revert any changes. The main planned change was to make the league ID a pick list since you already had all the data in the integration (see screenshot below for what it looks like). While I was doing this, I did a couple of other things which I think improve the code but again, happy to revert if you'd like:

- Switch list of lists to dictionaries which makes lookup of icon and the path data easier
- Run black formatter on all code
- Add picklist for the league, including the ability to pick specifying custom paths
- Add config validation for YAML configs to check if the league ID is valid
- Raise an error for YAML configs if league ID is XXX but sport or league path is missing
- Created constants for the sports paths which IMO just makes it less likely for someone to fat finger something
- Add missing typehints in some places (didn't cover everything)

Hope you find these changes useful!

<img width="350" alt="image" src="https://user-images.githubusercontent.com/7243222/235421456-ebdb54a3-4472-4fc7-8a02-7188b56955e8.png">


