### PR TITLE
v0.8.0 Release Candidate

### DIFF
--- a/custom_components/teamtracker/const.py
+++ b/custom_components/teamtracker/const.py
@@ -180,7 +180,7 @@ DEFAULT_KICKOFF_IN = "{test} days"
 
 # Misc
 TEAM_ID = ""
-VERSION = "v0.7.6"
+VERSION = "v0.8.0"
 ISSUE_URL = "https://github.com/vasqued2/ha-teamtracker"
 DOMAIN = "teamtracker"
 ATTRIBUTION = "Data provided by ESPN"

--- a/custom_components/teamtracker/const.py
+++ b/custom_components/teamtracker/const.py
@@ -180,7 +180,7 @@ DEFAULT_KICKOFF_IN = "{test} days"
 
 # Misc
 TEAM_ID = ""
-VERSION = "v0.7.5"
+VERSION = "v0.7.6"
 ISSUE_URL = "https://github.com/vasqued2/ha-teamtracker"
 DOMAIN = "teamtracker"
 ATTRIBUTION = "Data provided by ESPN"

--- a/custom_components/teamtracker/sensor.py
+++ b/custom_components/teamtracker/sensor.py
@@ -39,7 +39,9 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Required(CONF_LEAGUE_ID, default=DEFAULT_LEAGUE): vol.Upper,
+        vol.Required(CONF_LEAGUE_ID, default=DEFAULT_LEAGUE): vol.All(
+            vol.Upper, vol.In([*LEAGUE_MAP.keys(), "XXX"])
+        ),
         vol.Required(CONF_TEAM_ID): cv.string,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): int,

--- a/custom_components/teamtracker/set_racing.py
+++ b/custom_components/teamtracker/set_racing.py
@@ -5,12 +5,18 @@ import logging
 from .utils import async_get_value
 
 _LOGGER = logging.getLogger(__name__)
-
+race_laps = {}
 
 async def async_set_racing_values(
     new_values, event, competition_index, team_index, lang, sensor_name
 ) -> bool:
     """Set racing specific values"""
+
+
+    #
+    #  Pylint doesn't recognize values set by setdefault() method
+    #
+    global race_laps  # pylint: disable=global-variable-not-assigned
 
     #    _LOGGER.debug("%s: async_set_racing_values() 0: %s", sensor_name, new_values)
 
@@ -44,9 +50,17 @@ async def async_set_racing_values(
         new_values["opponent_rank"] = oppo_index + 1
     #    _LOGGER.debug("%s: async_set_racing_values() 3: %s", sensor_name, new_values)
 
-    new_values["team_total_shots"] = await async_get_value(
-        competition, "status", "period"
+    race_key = (
+        str(new_values["league"])
+        + "-"
+        + str(new_values["event_name"])
     )
+    new_values["team_total_shots"] = await async_get_value(
+        competition, "status", "period",
+        default=race_laps.setdefault(race_key, 0),
+    )
+    race_laps.update({race_key: new_values["team_total_shots"]})
+
     new_values["quarter"] = await async_get_value(competition, "type", "abbreviation")
     #    _LOGGER.debug("%s: async_set_racing_values() 4: %s", sensor_name, new_values)
 


### PR DESCRIPTION
* Require valid league_id's in YAML configurations
* Retain lap number in NASCAR races even if API doesn't return a value

NOTE:  Prior versions of teamtracker would allow invalid league_id's in YAML.  This version will not.  You must correct invalid values to pass the Configuration Test.