### PR TITLE
Added CLA (Conmebol Libertadores of América cup) league

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The following leagues are supported natively:
 - Hockey - NHL
 - MMA - UFC
 - U.S. Soccer - MLS, NWSL
-- International Soccer - BUND (German Bundesliga), CL (Champions League), EPL (English Premiere League), LIGA (Spanish LaLiga), LIG1 (French Ligue 1), SERA (Italian Serie A), WC (World Cup), WWC (Women's World Cup)
+- International Soccer - BUND (German Bundesliga), CL (Champions League), CLA (Conmebol Libertadores), EPL (English Premiere League), LIGA (Spanish LaLiga), LIG1 (French Ligue 1), SERA (Italian Serie A), WC (World Cup), WWC (Women's World Cup)
 - Racing - F1, IRL
 - Tennis - ATP, WTA
 - Volleyball - NCAAVB, NCAAVBW
@@ -226,6 +226,7 @@ For the League, the following values are valid:
 - ATP (Assc. of Tennis Professionals)
 - BUND (German Bundesliga)
 - CL (Champions League)
+- CLA (Conmebol Libertadores)
 - EPL (English Premiere League)
 - F1 (Formula 1 Racing)
 - IRL (Indy Racing League)

--- a/custom_components/teamtracker/const.py
+++ b/custom_components/teamtracker/const.py
@@ -104,6 +104,10 @@ LEAGUE_MAP = {
         CONF_SPORT_PATH: SOCCER,
         CONF_LEAGUE_PATH: "uefa.champions",
     },
+    "CLA": {
+        CONF_SPORT_PATH: SOCCER,
+        CONF_LEAGUE_PATH: "conmebol.libertadores",
+    },
     "EPL": {
         CONF_SPORT_PATH: SOCCER,
         CONF_LEAGUE_PATH: "eng.1",

--- a/custom_components/teamtracker/translations/en.json
+++ b/custom_components/teamtracker/translations/en.json
@@ -5,7 +5,7 @@
     },
     "step": {
       "user": {
-        "description": "Enter the League and Team to create the sensor.\n\nLeague: NFL, NCAAF, MLB, NBA, WNBA, NCAAM, NCAAW, NCAAVB, NCAAVBW, MLS, NWSL, BUND, CL, EPL, LIGA, LIG1, SERA, WC, PGA, ATP, WTA, F1, IRL, XFL\n\nTeam: 2-4 letter team abreviation used on ESPN's scoreboards and stats pages\n\nConference Number: For NCAA football and basketball only.  See README.md for valid values.  Leave blank to only include games with ranked teams.",
+        "description": "Enter the League and Team to create the sensor.\n\nLeague: NFL, NCAAF, MLB, NBA, WNBA, NCAAM, NCAAW, NCAAVB, NCAAVBW, MLS, NWSL, BUND, CL, CLA, EPL, LIGA, LIG1, SERA, WC, PGA, ATP, WTA, F1, IRL, XFL\n\nTeam: 2-4 letter team abreviation used on ESPN's scoreboards and stats pages\n\nConference Number: For NCAA football and basketball only.  See README.md for valid values.  Leave blank to only include games with ranked teams.",
         "data": {
           "league_id": "League",
           "team_id": "Team/Athlete",  

--- a/custom_components/teamtracker/translations/fr.json
+++ b/custom_components/teamtracker/translations/fr.json
@@ -5,7 +5,7 @@
         },
         "step": {
         "user": {
-            "description": "Entrée le championnat et l'équipe pour créer le sensor.\n\nChampionnat: NFL, NCAAF, MLB, NBA, WNBA, NCAAM, NCAAW, NCAAVB, NCAAVBW, MLS, NWSL, BUND, CL, EPL, LIGA, LIG1, SERA, WC, PGA, ATP, WTA, F1, IRL, XFL\n\nEquipe: Abréviation de l'équipe en 2-4 lettres comme utilisé sur le tableau des scores ESPN et la page des statistiques\n\nNuméro de Conference: Pour NCAA football et basketball seulement.  voir README.md pour les bonnes valeurs.  Laissez le champs videpour inclure uniquement des sports avec classements d'équipes.",
+            "description": "Entrée le championnat et l'équipe pour créer le sensor.\n\nChampionnat: NFL, NCAAF, MLB, NBA, WNBA, NCAAM, NCAAW, NCAAVB, NCAAVBW, MLS, NWSL, BUND, CL, CLA, EPL, LIGA, LIG1, SERA, WC, PGA, ATP, WTA, F1, IRL, XFL\n\nEquipe: Abréviation de l'équipe en 2-4 lettres comme utilisé sur le tableau des scores ESPN et la page des statistiques\n\nNuméro de Conference: Pour NCAA football et basketball seulement.  voir README.md pour les bonnes valeurs.  Laissez le champs videpour inclure uniquement des sports avec classements d'équipes.",
             "data": {
             "league_id": "Championnat",
             "team_id": "Equipe/Athlète",  

--- a/custom_components/teamtracker/translations/pt-BR.json
+++ b/custom_components/teamtracker/translations/pt-BR.json
@@ -6,7 +6,7 @@
     "step": {
       "user": {
         "title": "Rastreador de equipe",
-        "description": "Digite a Liga e a Equipe para criar o sensor.\n\nLiga: NFL, NCAAF, MLB, NBA, WNBA, NCAAM, NCAAW, NCAAVB, NCAAVBW, MLS, NWSL, BUND, CL, EPL, LIGA, LIG1, SERA, WC, PGA, ATP, WTA, F1, IRL, XFL\n\nEquipe : abreviação de equipe de 2 a 4 letras usada nos placares e nas páginas de estatísticas da ESPN\n\nNúmero da conferência: somente para futebol e basquete da NCAA. Consulte README.md para valores válidos. Deixe em branco para incluir apenas jogos com equipes classificadas.",
+        "description": "Digite a Liga e a Equipe para criar o sensor.\n\nLiga: NFL, NCAAF, MLB, NBA, WNBA, NCAAM, NCAAW, NCAAVB, NCAAVBW, MLS, NWSL, BUND, CL, CLA, EPL, LIGA, LIG1, SERA, WC, PGA, ATP, WTA, F1, IRL, XFL\n\nEquipe : abreviação de equipe de 2 a 4 letras usada nos placares e nas páginas de estatísticas da ESPN\n\nNúmero da conferência: somente para futebol e basquete da NCAA. Consulte README.md para valores válidos. Deixe em branco para incluir apenas jogos com equipes classificadas.",
         "data": {
           "league_id": "Liga",
           "team_id": "Time",  

--- a/custom_components/teamtracker/translations/sk.json
+++ b/custom_components/teamtracker/translations/sk.json
@@ -5,7 +5,7 @@
     },
     "step": {
       "user": {
-        "description": "Zadajte ligu a tím a vytvorte senzor.\n\nLiga: NFL, NCAAF, MLB, NBA, WNBA, NCAAM, NCAAW, NCAAVB, NCAAVBW, MLS, NWSL, BUND, CL, EPL, LIGA, LIG1, SERA, WC, PGA, ATP, WTA, F1, IRL, XFL\n\nTeam: 2-4-písmenová skratka tímu používaná na výsledkovej tabuli ESPN a na stránkach so štatistikami\n\nKonferenčné číslo: Len pre futbal a basketbal NCAA. Platné hodnoty nájdete v súbore README.md. Ak chcete zahrnúť iba hry s hodnotenými tímami, nechajte pole prázdne.",
+        "description": "Zadajte ligu a tím a vytvorte senzor.\n\nLiga: NFL, NCAAF, MLB, NBA, WNBA, NCAAM, NCAAW, NCAAVB, NCAAVBW, MLS, NWSL, BUND, CL, CLA, EPL, LIGA, LIG1, SERA, WC, PGA, ATP, WTA, F1, IRL, XFL\n\nTeam: 2-4-písmenová skratka tímu používaná na výsledkovej tabuli ESPN a na stránkach so štatistikami\n\nKonferenčné číslo: Len pre futbal a basketbal NCAA. Platné hodnoty nájdete v súbore README.md. Ak chcete zahrnúť iba hry s hodnotenými tímami, nechajte pole prázdne.",
         "data": {
           "league_id": "Liga",
           "team_id": "Tím/Športovec",  


### PR DESCRIPTION
Hello @vasqued2 ,

- Added 'Conmebol Libertadores' of América league (This most important soccer competition in South America like the Uefa Champions League is in Europe).
- Updated the description of translation files adding the CLA code.

I attached images with the CLA league implementation

![CLA-Test1](https://github.com/vasqued2/ha-teamtracker/assets/5523042/14eaa3ce-1066-41c1-9986-5a8d9a47b615)
![CLA-Test3](https://github.com/vasqued2/ha-teamtracker/assets/5523042/b70fe7b1-3930-4761-98c5-e8c06ee43ef0)
![CLA-Test2](https://github.com/vasqued2/ha-teamtracker/assets/5523042/ee58191f-a087-4360-b419-32b686cfeca0)

