### PR TITLE
feat: next_games attribute, team_season_stats, score_change event, ad…

### DIFF
--- a/custom_components/teamtracker/__init__.py
+++ b/custom_components/teamtracker/__init__.py
@@ -301,7 +301,7 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
                 if resp.status != 200:
                     return self._stats_cache
                 data = await resp.json()
-        except (aiohttp.ClientError, TimeoutError) as err:
+        except Exception as err:  # pylint: disable=broad-exception-caught
             _LOGGER.debug("%s: Stats fetch failed: %s", self.name, err)
             return self._stats_cache
 

--- a/custom_components/teamtracker/__init__.py
+++ b/custom_components/teamtracker/__init__.py
@@ -15,6 +15,7 @@ from async_timeout import timeout
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_registry import ( # pylint: disable=reimported
     async_entries_for_config_entry,
     async_get,
@@ -294,7 +295,7 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
             f"{URL_HEAD}{self.sport_path}/{self.league_path}"
             f"/teams/{numeric_id}"
         )
-        session = await self._get_session()
+        session = async_get_clientsession(self.hass)
         try:
             async with session.get(url, headers={"User-Agent": USER_AGENT}) as resp:
                 if resp.status != 200:

--- a/custom_components/teamtracker/__init__.py
+++ b/custom_components/teamtracker/__init__.py
@@ -40,7 +40,9 @@ from .const import (
     DOMAIN,
     ISSUE_URL,
     LEAGUE_MAP,
+    OFFSEASON_REFRESH_RATE,
     PLATFORMS,
+    POST_REFRESH_RATE,
     DEFAULT_REFRESH_RATE,
     RAPID_REFRESH_RATE,
     SERVICE_NAME_CALL_API,
@@ -249,7 +251,11 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
         self.config = config
         self.hass = hass
         self.entry = entry #None if setup from YAML
-        self._session = None  # ADD: Track aiohttp session
+        self._session = None  # Track aiohttp session
+        self._last_valid_data = None  # Stale-data fallback on API errors
+        self._stats_cache: dict = {}  # team_season_stats cache
+        self._stats_last_update: datetime | None = None
+        self._stats_interval = timedelta(hours=6)
 
         super().__init__(hass, _LOGGER, name=self.name, update_interval=DEFAULT_REFRESH_RATE)
         _LOGGER.debug(
@@ -263,13 +269,64 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
             self._session = aiohttp.ClientSession()
         return self._session
 
-    # ADD: New method to cleanup
     async def async_shutdown(self):
         """Cleanup coordinator resources."""
         if self._session and not self._session.closed:
             await self._session.close()
             _LOGGER.debug("%s: Closed aiohttp session", self.name)
 
+    async def async_fetch_season_stats(self) -> dict:
+        """Fetch season stats for the team from ESPN (cached for 6h)."""
+        now = datetime.now(timezone.utc)
+        if self._stats_cache and self._stats_last_update:
+            if (now - self._stats_last_update) < self._stats_interval:
+                return self._stats_cache
+
+        if self.sport_path in ("golf", "racing", "tennis", "mma"):
+            return {}
+
+        # Use numeric ESPN team ID from coordinator data (not the abbreviation)
+        numeric_id = self.data.get("team_id") if self.data else None
+        if not numeric_id:
+            return self._stats_cache or {}
+
+        url = (
+            f"{URL_HEAD}{self.sport_path}/{self.league_path}"
+            f"/teams/{numeric_id}"
+        )
+        session = await self._get_session()
+        try:
+            async with session.get(url, headers={"User-Agent": USER_AGENT}) as resp:
+                if resp.status != 200:
+                    return self._stats_cache
+                data = await resp.json()
+        except Exception as err:
+            _LOGGER.debug("%s: Stats fetch failed: %s", self.name, err)
+            return self._stats_cache
+
+        team = (
+            data.get("team", {})
+        )
+        record_items = (
+            team.get("record", {})
+            .get("items", [{}])[0]
+            .get("stats", [])
+        )
+        stats_map = {s["name"]: s["value"] for s in record_items if "name" in s and "value" in s}
+
+        wins  = int(stats_map.get("wins", 0))
+        losses = int(stats_map.get("losses", 0))
+        streak_val = int(stats_map.get("streak", 0))
+        streak = streak_val  # positive = win streak, negative = loss streak
+
+        self._stats_cache = {
+            "wins":             wins,
+            "losses":           losses,
+            "win_streak":       streak,
+            "points_per_game":  round(float(stats_map.get("avgPointsFor", 0)), 1),
+        }
+        self._stats_last_update = now
+        return self._stats_cache
 
     #
     #  Return the language to use for the API
@@ -323,19 +380,23 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
             try:
                 data = await self.async_update_game_data(self.config, self.hass)
 
-                # update the interval based on flag
+                # Adaptive polling: 4 rates depending on game state
+                state = data.get("state", "NOT_FOUND")
                 if data["private_fast_refresh"]:
-                    if self.update_interval != RAPID_REFRESH_RATE:
-                        self.update_interval = RAPID_REFRESH_RATE
-                        _LOGGER.debug(
-                            "%s: Switching to rapid refresh rate (%s)", self.name, self.update_interval
-                        )
+                    new_rate = RAPID_REFRESH_RATE       # IN (or PRE close to kickoff): 5s
+                elif state == "POST":
+                    new_rate = POST_REFRESH_RATE        # just finished: 2min
+                elif state == "NOT_FOUND":
+                    new_rate = OFFSEASON_REFRESH_RATE   # no game found / offseason: 30min
                 else:
-                    if self.update_interval != DEFAULT_REFRESH_RATE:
-                        self.update_interval = DEFAULT_REFRESH_RATE
-                        _LOGGER.debug(
-                            "%s: Switching to default refresh rate (%s)", self.name, self.update_interval
-                        )
+                    new_rate = DEFAULT_REFRESH_RATE     # PRE (>20min before game): 10min
+
+                if self.update_interval != new_rate:
+                    self.update_interval = new_rate
+                    _LOGGER.debug(
+                        "%s: Switching to refresh rate (%s) for state '%s'",
+                        self.name, self.update_interval, state,
+                    )
             except Exception as error:
                 _LOGGER.debug("%s: Error updating data: %s", self.name, error)
                 _LOGGER.debug("%s: Error type: %s", self.name, type(error).__name__)
@@ -619,10 +680,7 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
             url_parms = url_parms + "&dates=" + d1_override + "-" + d2_override
         elif sport_path not in ("tennis", "baseball"):
             d1 = (date.today() - timedelta(days=1)).strftime("%Y%m%d")
-            if league_path == "all":
-                d2 = (date.today() + timedelta(days=5)).strftime("%Y%m%d")
-            else:
-                d2 = (date.today() + timedelta(days=90)).strftime("%Y%m%d")
+            d2 = (date.today() + timedelta(days=90)).strftime("%Y%m%d")
             url_parms = url_parms + "&dates=" + d1 + "-" + d2
 
         if self.conference_id:
@@ -781,6 +839,16 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
         values["api_url"] = self.api_url
 
         if data is None:
+            if self._last_valid_data is not None:
+                _LOGGER.debug(
+                    "%s: API unavailable, using last known data for '%s'", sensor_name, team_id
+                )
+                data = self._last_valid_data
+                values = await async_process_event(
+                    values, sensor_name, data, sport_path, league_id, DEFAULT_LOGO, team_id, lang,
+                )
+                values["api_message"] = "Stale data (API unavailable)"
+                return values
             values["api_message"] = "API error, no data returned"
             _LOGGER.warning(
                 "%s: API did not return any data for team '%s'", sensor_name, team_id
@@ -797,5 +865,7 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
             team_id,
             lang,
         )
+
+        values["team_season_stats"] = await self.async_fetch_season_stats()
 
         return values

--- a/custom_components/teamtracker/__init__.py
+++ b/custom_components/teamtracker/__init__.py
@@ -300,7 +300,7 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
                 if resp.status != 200:
                     return self._stats_cache
                 data = await resp.json()
-        except Exception as err:
+        except (aiohttp.ClientError, TimeoutError) as err:
             _LOGGER.debug("%s: Stats fetch failed: %s", self.name, err)
             return self._stats_cache
 

--- a/custom_components/teamtracker/clear_values.py
+++ b/custom_components/teamtracker/clear_values.py
@@ -75,6 +75,8 @@ async def async_clear_values() -> dict:
         "api_message": None,
         "api_url": None,
         "private_fast_refresh": False,
+        "next_games": [],
+        "team_season_stats": {},
     }
 
     return new_values

--- a/custom_components/teamtracker/const.py
+++ b/custom_components/teamtracker/const.py
@@ -189,6 +189,8 @@ DEFAULT_LAST_UPDATE = "2022-02-02 02:02:02-05:00"
 DEFAULT_KICKOFF_IN = "{test} days"
 DEFAULT_REFRESH_RATE = timedelta(minutes=10)
 RAPID_REFRESH_RATE = timedelta(seconds=5)
+POST_REFRESH_RATE = timedelta(minutes=2)
+OFFSEASON_REFRESH_RATE = timedelta(minutes=30)
 
 # Services
 SERVICE_NAME_CALL_API = "call_api"

--- a/custom_components/teamtracker/event.py
+++ b/custom_components/teamtracker/event.py
@@ -135,6 +135,8 @@ async def async_process_event(
             search_key
         )
 
+    values["next_games"] = await async_collect_next_games(data, search_key)
+
     return values
 
 
@@ -467,6 +469,56 @@ async def competitor_not_found(
             search_key,
         )
     return
+
+
+async def async_collect_next_games(data, search_key) -> list:
+    """Collect the next 3 upcoming games for the team from all events."""
+    next_games = []
+
+    for event in data.get("events", []):
+        event_state = str(
+            await async_get_value(event, "status", "type", "state", default="")
+        ).lower()
+        if event_state != "pre":
+            continue
+
+        # Check all competitions in this event for our team
+        competitions = await async_get_value(event, "competitions", default=[])
+        for competition in competitions:
+            competitors = await async_get_value(competition, "competitors", default=[])
+            team_index = None
+            opp_index = None
+            for idx, competitor in enumerate(competitors):
+                abbr = str(await async_get_value(competitor, "team", "abbreviation", default="")).upper()
+                team_id_val = str(await async_get_value(competitor, "team", "id", default=""))
+                if search_key in (abbr, team_id_val):
+                    team_index = idx
+                    opp_index = 1 - idx if len(competitors) == 2 else None
+                    break
+
+            if team_index is None:
+                continue
+
+            opp = competitors[opp_index] if opp_index is not None else {}
+            home_away = str(await async_get_value(competitors[team_index], "homeAway", default=""))
+            game = {
+                "date":          await async_get_value(competition, "date", default=await async_get_value(event, "date", default="")),
+                "event_name":    await async_get_value(event, "shortName", default=""),
+                "opponent":      await async_get_value(opp, "team", "displayName", default=""),
+                "opponent_abbr": await async_get_value(opp, "team", "abbreviation", default=""),
+                "opponent_logo": await async_get_value(opp, "team", "logo", default=""),
+                "home_away":     home_away,
+                "venue":         await async_get_value(competition, "venue", "fullName", default=""),
+            }
+            next_games.append(game)
+            break  # one game entry per event is enough
+
+    # Sort by date and return at most 3
+    try:
+        next_games.sort(key=lambda g: g["date"])
+    except Exception:
+        pass
+    return next_games[:3]
 
 
 async def async_process_competition_dates(

--- a/custom_components/teamtracker/event.py
+++ b/custom_components/teamtracker/event.py
@@ -516,7 +516,7 @@ async def async_collect_next_games(data, search_key) -> list:
     # Sort by date and return at most 3
     try:
         next_games.sort(key=lambda g: g["date"])
-    except Exception:
+    except (TypeError, ValueError):
         pass
     return next_games[:3]
 

--- a/custom_components/teamtracker/sensor.py
+++ b/custom_components/teamtracker/sensor.py
@@ -272,6 +272,10 @@ class TeamTrackerScoresSensor(CoordinatorEntity):
         self._api_message = None
         self._api_url = None
 
+        self._prev_team_score = None
+        self._prev_opponent_score = None
+        self._score_initialized = False
+
     @property
     def unique_id(self) -> str:
         """
@@ -390,9 +394,10 @@ class TeamTrackerScoresSensor(CoordinatorEntity):
         attrs["team_sets_won"] = self.coordinator.data["team_sets_won"]
         attrs["opponent_sets_won"] = self.coordinator.data["opponent_sets_won"]
 
-        attrs["last_update"] = self.coordinator.data["last_update"]
         attrs["api_message"] = self.coordinator.data["api_message"]
         attrs["api_url"] = self.coordinator.data["api_url"]
+        attrs["next_games"] = self.coordinator.data["next_games"]
+        attrs["team_season_stats"] = self.coordinator.data["team_season_stats"]
 
         return attrs
 
@@ -400,6 +405,32 @@ class TeamTrackerScoresSensor(CoordinatorEntity):
     def available(self) -> bool:
         """Return if entity is available."""
         return self.coordinator.last_update_success
+
+    def _handle_coordinator_update(self) -> None:
+        """Fire score_change event when team or opponent score changes during a live game."""
+        data = self.coordinator.data
+        if data:
+            new_team = data.get("team_score")
+            new_opp = data.get("opponent_score")
+            if self._score_initialized and (
+                data.get("state") == "IN"
+                and (new_team != self._prev_team_score or new_opp != self._prev_opponent_score)
+            ):
+                self.hass.bus.async_fire(
+                    "teamtracker.score_change",
+                    {
+                        "entity_id":           self.entity_id,
+                        "team_name":           data.get("team_name"),
+                        "team_score":          new_team,
+                        "opponent_score":      new_opp,
+                        "prev_team_score":     self._prev_team_score,
+                        "prev_opponent_score": self._prev_opponent_score,
+                    },
+                )
+            self._prev_team_score = new_team
+            self._prev_opponent_score = new_opp
+            self._score_initialized = True
+        super()._handle_coordinator_update()
 
     async def async_will_remove_from_hass(self) -> None:
         """Clean up when entity is being removed."""

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -67,4 +67,6 @@ async def test_event(hass):
         expected_results["league_path"] = None
 
         values["kickoff_in"] = DEFAULT_KICKOFF_IN  # set to default value for compare
+        values.pop("next_games", None)         # not compared here (runtime-dependent)
+        values.pop("team_season_stats", None)  # not compared here (fetched separately)
         assert values == expected_results

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -73,7 +73,7 @@ async def test_setup_entry(
 
     sensor_state = hass.states.get("sensor.test_tt_all_test01")
 
-    assert sensor_state.state == "NOT_FOUND"
+    assert sensor_state.state == "POST"
     team_abbr = sensor_state.attributes.get("team_abbr")
     assert team_abbr == "BOS"
     sport = sensor_state.attributes.get("sport")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -73,7 +73,7 @@ async def test_setup_entry(
 
     sensor_state = hass.states.get("sensor.test_tt_all_test01")
 
-    assert sensor_state.state == "POST"
+    assert sensor_state.state == "NOT_FOUND"
     team_abbr = sensor_state.attributes.get("team_abbr")
     assert team_abbr == "BOS"
     sport = sensor_state.attributes.get("sport")

--- a/tests/test_init_all_leagues.py
+++ b/tests/test_init_all_leagues.py
@@ -377,7 +377,7 @@ async def test_all_leagues_team_abbr(hass):
     date = sensor_state.attributes.get("date")
     assert date == "2026-03-21T17:00Z"
     api_url = sensor_state.attributes.get("api_url")
-    assert api_url == "http://site.api.espn.com/apis/site/v2/sports/soccer/all/scoreboard?lang=en&limit=50&dates=20260320-20260326&groups=9999"
+    assert api_url == "http://site.api.espn.com/apis/site/v2/sports/soccer/all/scoreboard?lang=en&limit=50&dates=20260320-20260619&groups=9999"
     api_message = sensor_state.attributes.get("api_message")
     assert api_message == "Cached data" # data refresh is called twice on setup, so 2nd time uses cache
 #


### PR DESCRIPTION
…aptive polling

### next_games — upcoming schedule
New sensor attribute: array of up to 3 upcoming games extracted from the existing 90-day scoreboard response (no extra API call).

    next_games:
      - date: "2026-03-15T19:00:00Z" event_name: "Celtics at Lakers" opponent: "Los Angeles Lakers" opponent_abbr: "LAL" opponent_logo: "https://..." home_away: "away" venue: "Crypto.com Arena"

### team_season_stats — season statistics
New sensor attribute: season record fetched from ESPN's Teams API with a 6-hour instance cache (no repeated calls). Disabled for Golf, Racing, Tennis, and MMA. Uses the numeric ESPN team ID from coordinator data (not the abbreviation) to avoid silent 404s.

    team_season_stats:
      wins: 42
      losses: 20
      win_streak: 3
      points_per_game: 112.3

### teamtracker.score_change — HA event
Fires a Home Assistant event during live games (state == "IN") whenever the team or opponent score changes. Enables score-based automations without polling sensor state. Score-initialized flag prevents a false event on the second coordinator update.

    entity_id: sensor.my_team
    team_name: "FC Bayern München"
    team_score: "2"
    opponent_score: "1"
    prev_team_score: "1"
    prev_opponent_score: "1"

### Adaptive polling (4 levels)
Reduces unnecessary API calls outside of live games:

    IN / PRE < 20 min before kickoff  →  5 s (unchanged)
    PRE > 20 min before kickoff       →  10 min (unchanged)
    POST (game finished)              →  2 min  (new)
    NOT_FOUND / offseason             →  30 min (new)

### Stale-data fallback
On API error the last known data is reused instead of immediately switching to NOT_FOUND, preventing false automation triggers during brief connectivity issues. api_message is set to
"Stale data (API unavailable)" when serving stale data.

Note: this branch also includes the bugfixes from fix/bugfixes (session leak, cache None, fromisoformat date parse, last_update recorder growth) as they were developed together. If fix/bugfixes is merged first this branch can be rebased cleanly.