### PR TITLE
Fix soccer 'all' league: NOT_FOUND for teams outside top 50 and missing competition name

### DIFF
--- a/custom_components/teamtracker/__init__.py
+++ b/custom_components/teamtracker/__init__.py
@@ -550,11 +550,20 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
                 )
             return None
 
-        # Use UTC date so games played late local time (e.g. 11 PM PDT =
-        # next day UTC) are included in the recent window.
         today_utc = datetime.now(timezone.utc).date()
+        yesterday_utc = today_utc - timedelta(days=1)
+        day_before_yesterday = today_utc - timedelta(days=2)
+
+        # Always check two recent windows. ESPN categorizes games under a
+        # different date window than the UTC kickoff time from the schedule
+        # endpoint (e.g. a March 17 PDT game appears in 20260317-20260318, not
+        # 20260318-20260319), so a single window can miss recent results.
+        await _scoreboard_call(
+            day_before_yesterday.strftime("%Y%m%d"),
+            yesterday_utc.strftime("%Y%m%d"),
+        )
         used_url = await _scoreboard_call(
-            (today_utc - timedelta(days=1)).strftime("%Y%m%d"),
+            yesterday_utc.strftime("%Y%m%d"),
             today_utc.strftime("%Y%m%d"),
         )
 
@@ -562,8 +571,8 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
             next_date = datetime.fromisoformat(
                 next_events[0]["date"][:10]
             ).date()
-            # Only make the upcoming call if its window differs from the recent window
-            # (e.g. avoid a duplicate call when the next game is today UTC).
+            # Only make the upcoming call if its window differs from the recent
+            # window (avoid a duplicate when the next game is today UTC).
             if next_date > today_utc:
                 upcoming_url = await _scoreboard_call(
                     (next_date - timedelta(days=1)).strftime("%Y%m%d"),


### PR DESCRIPTION
## Problem

Two related issues when using `league_path: all` for soccer:

**1. NOT_FOUND for lesser-followed leagues**
The `soccer/all` scoreboard returns up to 50 events globally. European competitions alone can fill those slots, bumping MLS and similar leagues past position 50. A team like Seattle Sounders (id `9726`) returns `NOT_FOUND` even when actively playing in CONCACAF, because their game never appears in the first 50 results.

**2. `league` attribute shows user-configured placeholder**
The `soccer/all` scoreboard events carry no competition name — only a `season.slug` (e.g. `round-of-16`) that doesn't identify which competition. Users are forced to hardcode a placeholder like `XXX` for `league_path: all` sensors.

## Solution

For every update where `league_path == all`, two additional lightweight calls are made:

- `soccer/all/teams/{id}` — provides `nextEvent` with the upcoming game date (for targeted scoreboard calls) and `season.displayName` per event
- `soccer/all/teams/{id}/schedule` — provides `season.displayName` for recent past events

**NOT_FOUND fallback:** If the primary scoreboard missed the team, two narrow targeted scoreboard calls are made — `yesterday–today` and `day-before/day-of` the next game — whose combined event count stays well under the 50-event limit. Data format is identical to the primary path, so logos, colors, odds, and TV network are all populated.

**Competition name:** An `event_id → competition_name` map is built from the team info and schedule data. After processing, the matched game's competition is looked up by ID from `values["event_url"]` and written to `values["league"]`, with any leading year (`2026` / `2025-26`) stripped.

## Results

| Sensor | Before | After |
|---|---|---|
| Seattle Sounders (`all`) | `NOT_FOUND` | `PRE`, `league: Concacaf Champions Cup` |
| Tottenham Hotspur (`all`) | `league: XXX` | `league: UEFA Champions League` |

Both sensors now show full logos, colors, odds, and TV network. The POST→PRE transition follows the same 18-hour rule as the primary scoreboard path.

## Test plan

- [x] MLS team with CONCACAF game upcoming (e.g. Seattle Sounders `9726`) — verify `PRE` state with correct logos, odds, TV network, and `league: Concacaf Champions Cup`
- [x] EPL team (e.g. Tottenham `367`) — verify unchanged behavior via primary path, `league: UEFA Champions League`
- [x] Verify POST→PRE transition fires correctly within 18 hours of kickoff
- [ ] Verify POST state shows after a game with correct competition name
- [ ] International break (no upcoming game) — verify most recent POST result shown
- [ ] Existing test suite passes