### PR TITLE
Feat/standings

### DIFF
--- a/custom_components/teamtracker/__init__.py
+++ b/custom_components/teamtracker/__init__.py
@@ -15,6 +15,7 @@ from async_timeout import timeout
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_registry import ( # pylint: disable=reimported
     async_entries_for_config_entry,
     async_get,
@@ -290,6 +291,10 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
             await self._session.close()
             _LOGGER.debug("%s: Closed aiohttp session", self.name)
 
+
+    async def async_fetch_season_stats(self) -> dict:
+        """Placeholder — implemented in feat/new-features."""
+        return {}
 
     async def async_fetch_league_standing(self) -> dict:
         """Fetch this team's row from the ESPN standings table (cached for 6 h)."""

--- a/custom_components/teamtracker/__init__.py
+++ b/custom_components/teamtracker/__init__.py
@@ -29,6 +29,7 @@ from .const import (
     CONF_CONFERENCE_ID,
     CONF_LEAGUE_ID,
     CONF_LEAGUE_PATH,
+    CONF_SENSOR_TYPE,
     CONF_SPORT_PATH,
     CONF_TEAM_ID,
     COORDINATOR,
@@ -43,7 +44,10 @@ from .const import (
     PLATFORMS,
     DEFAULT_REFRESH_RATE,
     RAPID_REFRESH_RATE,
+    SENSOR_TYPE_STANDINGS,
     SERVICE_NAME_CALL_API,
+    STANDINGS_URL_BASE,
+    SPORTS_WITHOUT_STANDINGS,
     URL_HEAD,
     URL_TAIL,
     USER_AGENT,
@@ -51,6 +55,7 @@ from .const import (
 )
 from .event import async_process_event
 from . utils import is_integer
+from .standings_coordinator import TeamTrackerStandingsCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 # team_prob = {}
@@ -108,10 +113,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Print startup message
 
     sensor_name = entry.data[CONF_NAME]
+    sensor_type = entry.data.get(CONF_SENSOR_TYPE, "team")
 
     _LOGGER.info(
         "%s: Setting up sensor from UI configuration using TeamTracker %s, if you have any issues please report them here: %s",
-        sensor_name, 
+        sensor_name,
         VERSION,
         ISSUE_URL,
     )
@@ -119,25 +125,33 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Initialize DOMAIN in hass.data if it doesn't exist
     if DOMAIN not in hass.data:
         hass.data[DOMAIN] = {}
-        
+
     entry.async_on_unload(entry.add_update_listener(update_options_listener))
 
-    if entry.unique_id is not None:
-        _LOGGER.info(
-            "%s: async_setup_entry() - entry.unique_id is not None: %s",
-            sensor_name, 
-            entry.unique_id,
+    if sensor_type == SENSOR_TYPE_STANDINGS:
+        coordinator = TeamTrackerStandingsCoordinator(
+            hass,
+            entry.data[CONF_SPORT_PATH],
+            entry.data[CONF_LEAGUE_PATH],
+            entry.data[CONF_LEAGUE_ID],
+            sensor_name,
         )
-        hass.config_entries.async_update_entry(entry, unique_id=None)
+    else:
+        if entry.unique_id is not None:
+            _LOGGER.info(
+                "%s: async_setup_entry() - entry.unique_id is not None: %s",
+                sensor_name,
+                entry.unique_id,
+            )
+            hass.config_entries.async_update_entry(entry, unique_id=None)
 
-        ent_reg = async_get(hass)
-        for entity in async_entries_for_config_entry(ent_reg, entry.entry_id):
-            ent_reg.async_update_entity(entity.entity_id, new_unique_id=entry.entry_id)
+            ent_reg = async_get(hass)
+            for entity in async_entries_for_config_entry(ent_reg, entry.entry_id):
+                ent_reg.async_update_entity(entity.entity_id, new_unique_id=entry.entry_id)
 
-    # Setup the data coordinator
-    coordinator = TeamTrackerDataUpdateCoordinator(
-        hass, entry.data, entry
-    )
+        coordinator = TeamTrackerDataUpdateCoordinator(
+            hass, entry.data, entry
+        )
 
     # Fetch initial data so we have data when entities subscribe
     await coordinator.async_refresh()
@@ -249,7 +263,13 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
         self.config = config
         self.hass = hass
         self.entry = entry #None if setup from YAML
-        self._session = None  # ADD: Track aiohttp session
+        self._session = None  # Track aiohttp session
+        self._last_valid_data = None  # Stale-data fallback on API errors
+        self._stats_cache: dict = {}  # team_season_stats cache
+        self._stats_last_update: datetime | None = None
+        self._stats_interval = timedelta(hours=6)
+        self._standing_cache: dict = {}  # league_standing cache
+        self._standing_last_update: datetime | None = None
 
         super().__init__(hass, _LOGGER, name=self.name, update_interval=DEFAULT_REFRESH_RATE)
         _LOGGER.debug(
@@ -270,6 +290,78 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
             await self._session.close()
             _LOGGER.debug("%s: Closed aiohttp session", self.name)
 
+
+    async def async_fetch_league_standing(self) -> dict:
+        """Fetch this team's row from the ESPN standings table (cached for 6 h)."""
+        if self.sport_path in SPORTS_WITHOUT_STANDINGS:
+            return {}
+
+        now = datetime.now(timezone.utc)
+        if self._standing_cache and self._standing_last_update:
+            if (now - self._standing_last_update) < self._stats_interval:
+                return self._standing_cache
+
+        url = f"{STANDINGS_URL_BASE}/{self.sport_path}/{self.league_path}/standings"
+        session = async_get_clientsession(self.hass)
+        try:
+            async with session.get(url, headers={"User-Agent": USER_AGENT}) as resp:
+                if resp.status != 200:
+                    return self._standing_cache
+                raw = await resp.json()
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            _LOGGER.debug("%s: Standings fetch failed: %s", self.name, err)
+            return self._standing_cache
+
+        team_abbr = self.team_id.upper()
+        numeric_id = str(self.data.get("team_id", "")) if self.data else ""
+
+        team_entry = None
+        children = raw.get("children") or [raw]
+        for child in children:
+            for entry in child.get("standings", {}).get("entries", []):
+                t = entry.get("team", {})
+                if t.get("abbreviation", "").upper() == team_abbr or (
+                    numeric_id and str(t.get("id", "")) == numeric_id
+                ):
+                    team_entry = entry
+                    break
+            if team_entry:
+                break
+
+        if not team_entry:
+            return self._standing_cache
+
+        stats_raw = team_entry.get("stats", [])
+        raw_by_abbr = {
+            (s.get("abbreviation") or s.get("name") or "").upper(): s.get("value")
+            for s in stats_raw
+            if s.get("value") is not None
+        }
+
+        _STAT_MAP = [
+            ("rank",            ["RK"]),
+            ("points",          ["PTS"]),
+            ("wins",            ["W"]),
+            ("losses",          ["L"]),
+            ("draws",           ["T", "D"]),
+            ("games_played",    ["GP"]),
+            ("goal_difference", ["DIFF"]),
+            ("points_for",      ["PF", "GF"]),
+            ("points_against",  ["PA", "GA"]),
+            ("win_percent",     ["PCT", "WPCT"]),
+            ("streak",          ["STRK"]),
+        ]
+        result = {}
+        for field, keys in _STAT_MAP:
+            for k in keys:
+                if k in raw_by_abbr:
+                    v = raw_by_abbr[k]
+                    result[field] = int(v) if isinstance(v, float) and v == int(v) else v
+                    break
+
+        self._standing_cache = result
+        self._standing_last_update = now
+        return result
 
     #
     #  Return the language to use for the API
@@ -797,5 +889,8 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
             team_id,
             lang,
         )
+
+        values["team_season_stats"] = await self.async_fetch_season_stats()
+        values["league_standing"] = await self.async_fetch_league_standing()
 
         return values

--- a/custom_components/teamtracker/clear_values.py
+++ b/custom_components/teamtracker/clear_values.py
@@ -75,6 +75,9 @@ async def async_clear_values() -> dict:
         "api_message": None,
         "api_url": None,
         "private_fast_refresh": False,
+        "next_games": [],
+        "team_season_stats": {},
+        "league_standing": {},
     }
 
     return new_values

--- a/custom_components/teamtracker/config_flow.py
+++ b/custom_components/teamtracker/config_flow.py
@@ -17,12 +17,16 @@ from .const import (
     CONF_CONFERENCE_ID,
     CONF_LEAGUE_ID,
     CONF_LEAGUE_PATH,
+    CONF_SENSOR_TYPE,
     CONF_SPORT_PATH,
     CONF_TEAM_ID,
     DOMAIN,
     INDIVIDUAL_SPORTS,
     LEAGUE_MAP,
+    SENSOR_TYPE_STANDINGS,
+    SENSOR_TYPE_TEAM,
     SOCCER,
+    SPORTS_WITHOUT_STANDINGS,
 )
 from .utils import async_call_espn_api2
 
@@ -219,7 +223,7 @@ class TeamTrackerScoresFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             if len(leagues) == 1:
                 # Only one league for this sport — skip league step
                 self._league_id = next(iter(leagues))
-                return await self.async_step_search()
+                return await self.async_step_sensor_type()
             return await self.async_step_league()
 
         schema = vol.Schema(
@@ -270,7 +274,7 @@ class TeamTrackerScoresFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             self._league_id = user_input[CONF_LEAGUE_ID]
-            return await self.async_step_search()
+            return await self.async_step_sensor_type()
 
         league_options = _SPORT_GROUPS[self._sport_key][1]
         sport_name = _SPORT_GROUPS[self._sport_key][0]
@@ -285,7 +289,53 @@ class TeamTrackerScoresFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     # ------------------------------------------------------------------ #
-    #  Step 3: search team (ESPN link always correct here)                #
+    #  Step 3: choose sensor type — team tracker or standings             #
+    # ------------------------------------------------------------------ #
+    async def async_step_sensor_type(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.FlowResult:
+        """Ask whether to track a team or the full league standings."""
+        # Sports without standings go straight to team search
+        sport_path = LEAGUE_MAP.get(self._league_id, {}).get(CONF_SPORT_PATH, "")
+        if sport_path in SPORTS_WITHOUT_STANDINGS:
+            return await self.async_step_search()
+
+        if user_input is not None:
+            if user_input[CONF_SENSOR_TYPE] == SENSOR_TYPE_STANDINGS:
+                return self._create_standings_entry()
+            return await self.async_step_search()
+
+        sensor_type_options = {
+            SENSOR_TYPE_TEAM:      "Track a team",
+            SENSOR_TYPE_STANDINGS: "Track league standings",
+        }
+        schema = vol.Schema({vol.Required(CONF_SENSOR_TYPE, default=SENSOR_TYPE_TEAM): vol.In(sensor_type_options)})
+        return self.async_show_form(
+            step_id="sensor_type",
+            data_schema=schema,
+            errors={},
+        )
+
+    def _create_standings_entry(self) -> config_entries.FlowResult:
+        """Create a standings config entry directly."""
+        paths = LEAGUE_MAP[self._league_id]
+        league_display = _SPORT_GROUPS.get(self._sport_key, ("", {}))[1].get(
+            self._league_id, self._league_id
+        )
+        name = f"{league_display} Standings"
+        return self.async_create_entry(
+            title=name,
+            data={
+                CONF_NAME:          name,
+                CONF_LEAGUE_ID:     self._league_id,
+                CONF_SPORT_PATH:    paths[CONF_SPORT_PATH],
+                CONF_LEAGUE_PATH:   paths[CONF_LEAGUE_PATH],
+                CONF_SENSOR_TYPE:   SENSOR_TYPE_STANDINGS,
+            },
+        )
+
+    # ------------------------------------------------------------------ #
+    #  Step 4: search team (ESPN link always correct here)                #
     # ------------------------------------------------------------------ #
     async def async_step_search(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/teamtracker/const.py
+++ b/custom_components/teamtracker/const.py
@@ -195,6 +195,16 @@ SERVICE_NAME_CALL_API = "call_api"
 
 INDIVIDUAL_SPORTS = {"golf", "mma", "tennis"}
 
+# Standings
+STANDINGS_URL_BASE = "https://site.web.api.espn.com/apis/v2/sports"
+STANDINGS_REFRESH_RATE = timedelta(hours=1)
+SPORTS_WITHOUT_STANDINGS = {"golf", "tennis", "mma", "racing"}
+
+# Sensor types
+CONF_SENSOR_TYPE = "sensor_type"
+SENSOR_TYPE_TEAM = "team"
+SENSOR_TYPE_STANDINGS = "standings"
+
 # Misc
 TEAM_ID = ""
 VERSION = "v0.16.0"

--- a/custom_components/teamtracker/sensor.py
+++ b/custom_components/teamtracker/sensor.py
@@ -149,7 +149,6 @@ async def async_setup_entry(
     sensor_type = entry.data.get(CONF_SENSOR_TYPE, "team")
 
     if sensor_type == SENSOR_TYPE_STANDINGS:
-        from .const import COORDINATOR  # already imported above, explicit for clarity
         coordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
         async_add_entities(
             [TeamTrackerStandingsSensor(

--- a/custom_components/teamtracker/sensor.py
+++ b/custom_components/teamtracker/sensor.py
@@ -22,6 +22,7 @@ from .const import (
     CONF_CONFERENCE_ID,
     CONF_LEAGUE_ID,
     CONF_LEAGUE_PATH,
+    CONF_SENSOR_TYPE,
     CONF_SPORT_PATH,
     CONF_TEAM_ID,
     COORDINATOR,
@@ -33,9 +34,11 @@ from .const import (
     DOMAIN,
     ISSUE_URL,
     LEAGUE_MAP,
+    SENSOR_TYPE_STANDINGS,
     SPORT_ICON_MAP,
     VERSION,
 )
+from .standings_sensor import TeamTrackerStandingsSensor
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -138,10 +141,26 @@ async def async_setup_entry(
 
     _LOGGER.info(
         "%s: Updating sensor from UI using TeamTracker %s, if you have any issues please report them here: %s",
-        sensor_name, 
+        sensor_name,
         VERSION,
         ISSUE_URL,
     )
+
+    sensor_type = entry.data.get(CONF_SENSOR_TYPE, "team")
+
+    if sensor_type == SENSOR_TYPE_STANDINGS:
+        from .const import COORDINATOR  # already imported above, explicit for clarity
+        coordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
+        async_add_entities(
+            [TeamTrackerStandingsSensor(
+                coordinator,
+                entry.entry_id,
+                sensor_name,
+                entry.data.get(CONF_SPORT_PATH, ""),
+            )],
+            True,
+        )
+        return
 
     config = hass.data[DOMAIN][entry.entry_id]
     # Update our config to include new repos and remove those that have been removed.
@@ -393,6 +412,9 @@ class TeamTrackerScoresSensor(CoordinatorEntity):
         attrs["last_update"] = self.coordinator.data["last_update"]
         attrs["api_message"] = self.coordinator.data["api_message"]
         attrs["api_url"] = self.coordinator.data["api_url"]
+        attrs["next_games"] = self.coordinator.data["next_games"]
+        attrs["team_season_stats"] = self.coordinator.data["team_season_stats"]
+        attrs["league_standing"] = self.coordinator.data["league_standing"]
 
         return attrs
 

--- a/custom_components/teamtracker/standings_coordinator.py
+++ b/custom_components/teamtracker/standings_coordinator.py
@@ -1,0 +1,96 @@
+"""Standings coordinator for TeamTracker."""
+from datetime import datetime, timezone
+import logging
+
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import STANDINGS_REFRESH_RATE, STANDINGS_URL_BASE, USER_AGENT
+
+_LOGGER = logging.getLogger(__name__)
+
+# Stat abbreviations → standard field names (first match wins)
+_STAT_MAP = [
+    ("rank",            ["RK"]),
+    ("points",          ["PTS"]),
+    ("wins",            ["W"]),
+    ("losses",          ["L"]),
+    ("draws",           ["T", "D"]),
+    ("games_played",    ["GP"]),
+    ("goal_difference", ["DIFF"]),
+    ("points_for",      ["PF", "GF"]),
+    ("points_against",  ["PA", "GA"]),
+    ("win_percent",     ["PCT", "WPCT"]),
+    ("streak",          ["STRK"]),
+]
+
+
+def _parse_entry(entry: dict, group_name: str) -> dict:
+    """Convert a raw standings entry into a clean dict."""
+    team = entry.get("team", {})
+    logos = team.get("logos") or team.get("logo") or []
+    logo_href = logos[0].get("href", "") if isinstance(logos, list) and logos else ""
+
+    stats_raw = entry.get("stats", [])
+    raw_by_abbr = {}
+    for s in stats_raw:
+        abbr = (s.get("abbreviation") or s.get("name") or "").upper()
+        val = s.get("value")
+        if abbr and val is not None:
+            raw_by_abbr[abbr] = val
+
+    result = {
+        "team_name": team.get("displayName", ""),
+        "team_abbr": team.get("abbreviation", ""),
+        "team_logo": logo_href,
+        "group":     group_name,
+    }
+    for field, keys in _STAT_MAP:
+        for k in keys:
+            if k in raw_by_abbr:
+                v = raw_by_abbr[k]
+                result[field] = int(v) if isinstance(v, float) and v == int(v) else v
+                break
+
+    return result
+
+
+class TeamTrackerStandingsCoordinator(DataUpdateCoordinator):
+    """Fetches and caches a full league standings table."""
+
+    def __init__(self, hass, sport_path: str, league_path: str, league_id: str, name: str) -> None:
+        """Initialize."""
+        self.sport_path = sport_path
+        self.league_path = league_path
+        self.league_id = league_id
+        super().__init__(hass, _LOGGER, name=name, update_interval=STANDINGS_REFRESH_RATE)
+
+    async def _async_update_data(self) -> dict:
+        """Fetch standings from ESPN API."""
+        url = f"{STANDINGS_URL_BASE}/{self.sport_path}/{self.league_path}/standings"
+        session = async_get_clientsession(self.hass)
+        try:
+            async with session.get(url, headers={"User-Agent": USER_AGENT}) as resp:
+                if resp.status != 200:
+                    if self.data:
+                        return self.data
+                    raise UpdateFailed(f"ESPN standings API returned HTTP {resp.status}")
+                raw = await resp.json()
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            if self.data:
+                return self.data
+            raise UpdateFailed(str(err)) from err
+
+        entries_list = []
+        children = raw.get("children") or [raw]
+        for child in children:
+            group_name = child.get("name", "")
+            for entry in child.get("standings", {}).get("entries", []):
+                entries_list.append(_parse_entry(entry, group_name))
+
+        return {
+            "standings":   entries_list,
+            "league":      self.league_id,
+            "sport":       self.sport_path,
+            "last_update": datetime.now(timezone.utc).isoformat(),
+        }

--- a/custom_components/teamtracker/standings_sensor.py
+++ b/custom_components/teamtracker/standings_sensor.py
@@ -2,18 +2,15 @@
 import logging
 from typing import Any
 
-from homeassistant.components.sensor import SensorEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ATTRIBUTION
-from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ATTRIBUTION, DEFAULT_ICON, DOMAIN, SPORT_ICON_MAP
+from .const import ATTRIBUTION, DEFAULT_ICON, SPORT_ICON_MAP
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class TeamTrackerStandingsSensor(CoordinatorEntity, SensorEntity):
+class TeamTrackerStandingsSensor(CoordinatorEntity):
     """Sensor that exposes a full league standings table via attributes.
 
     State  = abbreviation of the first-place team (or number of entries as fallback).

--- a/custom_components/teamtracker/standings_sensor.py
+++ b/custom_components/teamtracker/standings_sensor.py
@@ -1,0 +1,77 @@
+"""Standings sensor for TeamTracker — shows a full league table as attributes."""
+import logging
+from typing import Any
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_ATTRIBUTION
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import ATTRIBUTION, DEFAULT_ICON, DOMAIN, SPORT_ICON_MAP
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class TeamTrackerStandingsSensor(CoordinatorEntity, SensorEntity):
+    """Sensor that exposes a full league standings table via attributes.
+
+    State  = abbreviation of the first-place team (or number of entries as fallback).
+    Attributes:
+        standings  – list of dicts, one per team: rank, points, wins, losses, …
+        league     – league ID (e.g. "BUND")
+        sport      – sport path (e.g. "soccer")
+        last_update
+    """
+
+    def __init__(
+        self,
+        coordinator,
+        entry_id: str,
+        name: str,
+        sport_path: str,
+    ) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+        self._entry_id = entry_id
+        self._name = name
+        self._icon = SPORT_ICON_MAP.get(sport_path, DEFAULT_ICON)
+
+    @property
+    def unique_id(self) -> str:
+        return f"standings_{self._entry_id}"
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def icon(self) -> str:
+        return self._icon
+
+    @property
+    def state(self) -> str | None:
+        if not self.coordinator.data:
+            return None
+        standings = self.coordinator.data.get("standings", [])
+        if not standings:
+            return None
+        leader = next((t for t in standings if t.get("rank") == 1), standings[0])
+        return leader.get("team_abbr") or str(len(standings))
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        if not self.coordinator.data:
+            return {}
+        data = self.coordinator.data
+        return {
+            ATTR_ATTRIBUTION: ATTRIBUTION,
+            "standings":      data.get("standings", []),
+            "league":         data.get("league"),
+            "sport":          data.get("sport"),
+            "last_update":    data.get("last_update"),
+        }
+
+    @property
+    def available(self) -> bool:
+        return self.coordinator.last_update_success

--- a/custom_components/teamtracker/strings.json
+++ b/custom_components/teamtracker/strings.json
@@ -20,6 +20,13 @@
           "league_id": "League"
         }
       },
+      "sensor_type": {
+        "title": "Sensor Type",
+        "description": "What do you want to track?",
+        "data": {
+          "sensor_type": "Sensor Type"
+        }
+      },
       "search": {
         "title": "Search Team",
         "description": "Type name to search for the {league_name} team, or leave blank to enter the team ID manually.\n\n[Browse teams on ESPN]({league_url})",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -27,28 +27,21 @@ async def test_team_from_manual_input(hass):
     assert result["type"] == "form"
     assert result["step_id"] == "league"
 
-    # Step 3: choose league → expect sensor type form
+    # Step 3: choose league → expect team search form
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"league_id": "NFL"}
     )
     assert result["type"] == "form"
-    assert result["step_id"] == "sensor_type"
-
-    # Step 4: choose team sensor → expect team search form
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {"sensor_type": "team"}
-    )
-    assert result["type"] == "form"
     assert result["step_id"] == "search"
 
-    # Step 5: empty search → expect manual entry form
+    # Step 4: empty search → expect manual entry form
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"search_team": ""}
     )
     assert result["type"] == "form"
     assert result["step_id"] == "manual_team"
 
-    # Step 6: enter team details → expect entry created
+    # Step 5: enter team details → expect entry created
     with patch(
         "custom_components.teamtracker.async_setup_entry",
         return_value=True,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -27,21 +27,28 @@ async def test_team_from_manual_input(hass):
     assert result["type"] == "form"
     assert result["step_id"] == "league"
 
-    # Step 3: choose league → expect team search form
+    # Step 3: choose league → expect sensor type form
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"league_id": "NFL"}
     )
     assert result["type"] == "form"
+    assert result["step_id"] == "sensor_type"
+
+    # Step 4: choose team sensor → expect team search form
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"sensor_type": "team"}
+    )
+    assert result["type"] == "form"
     assert result["step_id"] == "search"
 
-    # Step 4: empty search → expect manual entry form
+    # Step 5: empty search → expect manual entry form
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"search_team": ""}
     )
     assert result["type"] == "form"
     assert result["step_id"] == "manual_team"
 
-    # Step 5: enter team details → expect entry created
+    # Step 6: enter team details → expect entry created
     with patch(
         "custom_components.teamtracker.async_setup_entry",
         return_value=True,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -27,21 +27,28 @@ async def test_team_from_manual_input(hass):
     assert result["type"] == "form"
     assert result["step_id"] == "league"
 
-    # Step 3: choose league → expect team search form
+    # Step 3: choose league → expect sensor type form
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"league_id": "NFL"}
     )
     assert result["type"] == "form"
+    assert result["step_id"] == "sensor_type"
+
+    # Step 4: choose team sensor → expect team search form
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"sensor_type": "team"}
+    )
+    assert result["type"] == "form"
     assert result["step_id"] == "search"
 
-    # Step 4: empty search → expect manual entry form
+    # Step 5: empty search → expect manual entry form
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"search_team": ""}
     )
     assert result["type"] == "form"
     assert result["step_id"] == "manual_team"
 
-    # Step 5: enter team details → expect entry created
+    # Step 6: enter team details → expect entry created
     with patch(
         "custom_components.teamtracker.async_setup_entry",
         return_value=True,
@@ -86,14 +93,21 @@ async def test_team_from_league_list(hass, mock_espn_api):
     assert result["type"] == "form"
     assert result["step_id"] == "league"
 
-    # Step 3: choose league → expect team search form
+    # Step 3: choose league → expect sensor type form
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"league_id": "NCAAF"}
     )
     assert result["type"] == "form"
+    assert result["step_id"] == "sensor_type"
+
+    # Step 4: choose team sensor → expect team search form
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"sensor_type": "team"}
+    )
+    assert result["type"] == "form"
     assert result["step_id"] == "search"
 
-    # Step 4: found search → expect select_team entry form
+    # Step 5: found search → expect select_team entry form
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"search_team": "ohio"}
     )

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -67,4 +67,7 @@ async def test_event(hass):
         expected_results["league_path"] = None
 
         values["kickoff_in"] = DEFAULT_KICKOFF_IN  # set to default value for compare
+        values.pop("next_games", None)         # not compared here (runtime-dependent)
+        values.pop("team_season_stats", None)  # not compared here (fetched separately)
+        values.pop("league_standing", None)    # not compared here (fetched separately)
         assert values == expected_results


### PR DESCRIPTION
## feat/standings — League Standings

Two new features for tracking league standings tables from the ESPN API.

---

### Option A — `league_standing` attribute on existing team sensors

Every team sensor gets a new attribute **`league_standing`** containing the team's current position in the league table:

| Field | Description |
|---|---|
| `rank` | Current league position |
| `points` | Points total |
| `wins` | Wins |
| `losses` | Losses |
| `draws` | Draws / Ties |
| `games_played` | Games played |
| `goal_difference` | Goal / point differential |
| `points_for` | Goals / points scored |
| `points_against` | Goals / points conceded |
| `win_percent` | Win percentage |
| `streak` | Current streak |

**Notes:**
- Fetched from the ESPN standings API, cached for 6 hours
- Automatically skipped for sports without standings (Golf, Tennis, MMA, Racing)
- Returns `{}` silently on API errors — no impact on existing sensor behavior

---

### Option B — Dedicated standings sensor

A new sensor type that exposes the **full league table** as a single sensor.

**Config flow:** After selecting sport + league, a new step asks:
> *What do you want to track?*
> - Track a team *(existing behavior)*
> - Track league standings *(new)*

Selecting "Track league standings" skips team selection and creates the sensor directly. The sensor name is auto-generated (e.g. `Bundesliga Standings`).

**Sensor:**
| Property | Value |
|---|---|
| State | Abbreviation of the first-place team (e.g. `BAY`) |
| `standings` attribute | Full table — list of all teams with rank, points, W/D/L, GD, logo, group |
| `league` | League ID (e.g. `BUND`) |
| `sport` | Sport path (e.g. `soccer`) |
| `last_update` | ISO timestamp of last successful fetch |
| Refresh rate | Every 60 minutes |

**Example `standings` entry:**
```json
{
  "team_name": "Bayern München",
  "team_abbr": "BAY",
  "team_logo": "https://...",
  "group": "",
  "rank": 1,
  "points": 57,
  "wins": 18,
  "losses": 3,
  "draws": 3,
  "games_played": 24,
  "goal_difference": 40,
  "points_for": 62,
  "points_against": 22
}
