### PR TITLE
Refactor all-league support to reuse existing scoreboard flow

### DIFF
--- a/custom_components/teamtracker/__init__.py
+++ b/custom_components/teamtracker/__init__.py
@@ -583,7 +583,7 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
         # Enrich league name from the competition the matched game belongs to.
         # Extract the game ID from the event URL (format: .../gameId/XXXXXXX/...)
         event_url = values.get("event_url", "") or ""
-        match = re.search(r"/gameId/(\d+)/", event_url)
+        match = re.search(r"/gameId/(\d+)", event_url)
         if match:
             game_id = match.group(1)
             competition = id_to_competition.get(game_id)

--- a/custom_components/teamtracker/__init__.py
+++ b/custom_components/teamtracker/__init__.py
@@ -362,6 +362,8 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
             if now < expiration:
                 data = self.data_cache[key]
                 values = await self.async_update_values(config, hass, data, lang)
+                if values["state"] == "NOT_FOUND" and league_path == "all":
+                    values = await self.async_try_team_schedule(config, hass, lang, values)
                 if values["api_message"]:
                     values["api_message"] = "Cached data: " + values["api_message"]
                 else:
@@ -377,6 +379,8 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
 
         data, file_override = await self.async_call_api(config, hass, lang)
         values = await self.async_update_values(config, hass, data, lang)
+        if values["state"] == "NOT_FOUND" and league_path == "all" and not file_override:
+            values = await self.async_try_team_schedule(config, hass, lang, values)
         self.data_cache[key] = data
         self.last_update[key] = values["last_update"]
 
@@ -396,6 +400,47 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
                         "%s: Error creating results file '%s'", sensor_name, path
                     )
         return values
+
+    async def async_try_team_schedule(self, config, hass, lang, prev_values) -> dict:
+        """Fallback: fetch team-specific schedule when team not found in 'all' scoreboard."""
+
+        team_id = self.team_id
+        sport_path = self.sport_path
+        league_path = self.league_path
+        sensor_name = self.name
+
+        url = (
+            URL_HEAD
+            + sport_path
+            + "/"
+            + league_path
+            + "/teams/"
+            + team_id
+            + "/schedule"
+        )
+        headers = {"User-Agent": USER_AGENT, "Accept": "application/ld+json"}
+
+        session = await self._get_session()
+        try:
+            async with session.get(url, headers=headers) as r:
+                _LOGGER.debug(
+                    "%s: Calling team schedule API for '%s' from %s",
+                    sensor_name,
+                    team_id,
+                    url,
+                )
+                if r.status == 200:
+                    schedule_data = await r.json()
+                    if schedule_data and "events" in schedule_data:
+                        self.api_url = url
+                        values = await self.async_update_values(
+                            config, hass, schedule_data, lang
+                        )
+                        return values
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            _LOGGER.debug("%s: Team schedule API call failed: %s", sensor_name, e)
+
+        return prev_values
 
     #
     #  Call the API (or file override) and get the data returned by it

--- a/custom_components/teamtracker/__init__.py
+++ b/custom_components/teamtracker/__init__.py
@@ -456,6 +456,7 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
         if cache_valid:
             id_to_competition = cached["id_to_competition"]
             next_events = cached["next_events"]
+            needs_fallback = cached["needs_fallback"]
             _LOGGER.debug("%s: all_team_cache hit for '%s'", sensor_name, team_id)
         else:
             # Full discovery: build event_id → competition name mapping from the
@@ -499,65 +500,71 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
             next_game_date = (
                 date.fromisoformat(next_events[0]["date"][:10]) if next_events else None
             )
+            needs_fallback = prev_values["state"] == "NOT_FOUND"
             TeamTrackerDataUpdateCoordinator.all_team_cache[cache_key] = {
-                "needs_fallback": prev_values["state"] == "NOT_FOUND",
+                "needs_fallback": needs_fallback,
                 "next_events": next_events,
                 "id_to_competition": id_to_competition,
                 "expires": next_game_date or today,
             }
 
-        values = prev_values
+        # Always run targeted narrow-window scoreboard calls for league_path == all.
+        # The primary scoreboard (50-event limit) may return a far-future game
+        # while a live or closer game exists in another competition.  Targeted
+        # calls use tight date windows so they reliably surface the current game.
+        # If targeted calls find a match it takes priority; otherwise we keep
+        # whatever the primary scoreboard found.
+        values = prev_values  # default: keep primary result
 
-        # If the primary scoreboard already found the team, just enrich league name.
-        if prev_values["state"] != "NOT_FOUND":
-            values = prev_values
-        else:
-            # Primary scoreboard missed the team (50-event limit). Fall back to
-            # targeted narrow-window scoreboard calls that keep event count low.
-            all_events = []
-            seen_ids = set()
+        all_events = []
+        seen_ids = set()
 
-            def _merge(new_events):
-                for e in new_events:
-                    eid = e.get("id")
-                    if eid not in seen_ids:
-                        seen_ids.add(eid)
-                        all_events.append(e)
+        def _merge(new_events):
+            for e in new_events:
+                eid = e.get("id")
+                if eid not in seen_ids:
+                    seen_ids.add(eid)
+                    all_events.append(e)
 
-            async def _scoreboard_call(d1_str, d2_str):
-                url = (
-                    scoreboard_base
-                    + "?lang=" + lang[:2]
-                    + "&limit=" + str(API_LIMIT)
-                    + "&dates=" + d1_str + "-" + d2_str
-                )
-                try:
-                    async with session.get(url, headers=headers) as r:
-                        _LOGGER.debug(
-                            "%s: Targeted scoreboard call for '%s' from %s",
-                            sensor_name, team_id, url,
-                        )
-                        if r.status == 200:
-                            data = await r.json()
-                            if data and "events" in data:
-                                _merge(data["events"])
-                                return url
-                except Exception as e:  # pylint: disable=broad-exception-caught
-                    _LOGGER.debug(
-                        "%s: Targeted scoreboard call failed: %s", sensor_name, e
-                    )
-                return None
-
-            today = date.today()
-            used_url = await _scoreboard_call(
-                (today - timedelta(days=1)).strftime("%Y%m%d"),
-                today.strftime("%Y%m%d"),
+        async def _scoreboard_call(d1_str, d2_str):
+            url = (
+                scoreboard_base
+                + "?lang=" + lang[:2]
+                + "&limit=" + str(API_LIMIT)
+                + "&dates=" + d1_str + "-" + d2_str
             )
+            try:
+                async with session.get(url, headers=headers) as r:
+                    _LOGGER.debug(
+                        "%s: Targeted scoreboard call for '%s' from %s",
+                        sensor_name, team_id, url,
+                    )
+                    if r.status == 200:
+                        data = await r.json()
+                        if data and "events" in data:
+                            _merge(data["events"])
+                            return url
+            except Exception as e:  # pylint: disable=broad-exception-caught
+                _LOGGER.debug(
+                    "%s: Targeted scoreboard call failed: %s", sensor_name, e
+                )
+            return None
 
-            if next_events:
-                next_date = datetime.fromisoformat(
-                    next_events[0]["date"][:10]
-                ).date()
+        # Use UTC date so games played late local time (e.g. 11 PM PDT =
+        # next day UTC) are included in the recent window.
+        today_utc = datetime.now(timezone.utc).date()
+        used_url = await _scoreboard_call(
+            (today_utc - timedelta(days=1)).strftime("%Y%m%d"),
+            today_utc.strftime("%Y%m%d"),
+        )
+
+        if next_events:
+            next_date = datetime.fromisoformat(
+                next_events[0]["date"][:10]
+            ).date()
+            # Only make the upcoming call if its window differs from the recent window
+            # (e.g. avoid a duplicate call when the next game is today UTC).
+            if next_date > today_utc:
                 upcoming_url = await _scoreboard_call(
                     (next_date - timedelta(days=1)).strftime("%Y%m%d"),
                     next_date.strftime("%Y%m%d"),
@@ -565,20 +572,22 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
                 if upcoming_url:
                     used_url = upcoming_url
 
-            if all_events:
-                self.api_url = used_url or scoreboard_base
-                values = await self.async_update_values(
-                    config, hass, {"events": all_events}, lang
-                )
+        if all_events:
+            self.api_url = used_url or scoreboard_base
+            targeted_values = await self.async_update_values(
+                config, hass, {"events": all_events}, lang
+            )
+            if targeted_values["state"] != "NOT_FOUND":
+                values = targeted_values
 
-            # Targeted calls returned NOT_FOUND — the cached game date is stale.
-            # Invalidate so the next tick does a full re-discovery.
-            if values["state"] == "NOT_FOUND" and cache_valid:
-                _LOGGER.debug(
-                    "%s: Invalidating stale all_team_cache for '%s'",
-                    sensor_name, team_id,
-                )
-                del TeamTrackerDataUpdateCoordinator.all_team_cache[cache_key]
+        # Targeted calls returned NOT_FOUND and primary also has nothing —
+        # the cached game date is stale.  Invalidate for re-discovery next tick.
+        if values["state"] == "NOT_FOUND" and cache_valid:
+            _LOGGER.debug(
+                "%s: Invalidating stale all_team_cache for '%s'",
+                sensor_name, team_id,
+            )
+            del TeamTrackerDataUpdateCoordinator.all_team_cache[cache_key]
 
         # Enrich league name from the competition the matched game belongs to.
         # Extract the game ID from the event URL (format: .../gameId/XXXXXXX/...)

--- a/custom_components/teamtracker/__init__.py
+++ b/custom_components/teamtracker/__init__.py
@@ -402,43 +402,99 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
         return values
 
     async def async_try_team_schedule(self, config, hass, lang, prev_values) -> dict:
-        """Fallback: fetch team-specific schedule when team not found in 'all' scoreboard."""
+        """Fallback for 'all' league: make targeted scoreboard calls so returned data
+        is identical in format to the primary scoreboard path.
+
+        Two narrow-window calls are made and their events combined:
+          1. yesterday–today: captures any POST/IN game (few events, no limit issue)
+          2. day-before–day-of next game (from nextEvent): captures the PRE game
+
+        The existing 18-hour transition rule then handles POST→PRE naturally,
+        matching the behaviour of teams found in the primary scoreboard.
+        """
 
         team_id = self.team_id
         sport_path = self.sport_path
         league_path = self.league_path
         sensor_name = self.name
 
-        url = (
-            URL_HEAD
-            + sport_path
-            + "/"
-            + league_path
-            + "/teams/"
-            + team_id
-            + "/schedule"
+        scoreboard_base = URL_HEAD + sport_path + "/" + league_path + URL_TAIL
+        team_url = (
+            URL_HEAD + sport_path + "/" + league_path + "/teams/" + team_id
         )
         headers = {"User-Agent": USER_AGENT, "Accept": "application/ld+json"}
-
         session = await self._get_session()
+
+        all_events = []
+        seen_ids = set()
+
+        def _merge(new_events):
+            for e in new_events:
+                eid = e.get("id")
+                if eid not in seen_ids:
+                    seen_ids.add(eid)
+                    all_events.append(e)
+
+        async def _scoreboard_call(d1_str, d2_str):
+            url = (
+                scoreboard_base
+                + "?lang=" + lang[:2]
+                + "&limit=" + str(API_LIMIT)
+                + "&dates=" + d1_str + "-" + d2_str
+            )
+            try:
+                async with session.get(url, headers=headers) as r:
+                    _LOGGER.debug(
+                        "%s: Targeted scoreboard call for '%s' from %s",
+                        sensor_name, team_id, url,
+                    )
+                    if r.status == 200:
+                        data = await r.json()
+                        if data and "events" in data:
+                            _merge(data["events"])
+                            return url
+            except Exception as e:  # pylint: disable=broad-exception-caught
+                _LOGGER.debug("%s: Targeted scoreboard call failed: %s", sensor_name, e)
+            return None
+
+        # Call 1: recent window (yesterday–today) — catches POST/IN games
+        today = date.today()
+        used_url = await _scoreboard_call(
+            (today - timedelta(days=1)).strftime("%Y%m%d"),
+            today.strftime("%Y%m%d"),
+        )
+
+        # Call 2: upcoming game window — catches the PRE game.
+        # Use nextEvent to find the exact game date so the window stays narrow.
         try:
-            async with session.get(url, headers=headers) as r:
+            async with session.get(team_url, headers=headers) as r:
                 _LOGGER.debug(
-                    "%s: Calling team schedule API for '%s' from %s",
-                    sensor_name,
-                    team_id,
-                    url,
+                    "%s: Team info call for '%s' from %s",
+                    sensor_name, team_id, team_url,
                 )
                 if r.status == 200:
-                    schedule_data = await r.json()
-                    if schedule_data and "events" in schedule_data:
-                        self.api_url = url
-                        values = await self.async_update_values(
-                            config, hass, schedule_data, lang
+                    team_data = await r.json()
+                    next_events = team_data.get("team", {}).get("nextEvent", [])
+                    if next_events:
+                        next_date = datetime.fromisoformat(
+                            next_events[0]["date"][:10]
+                        ).date()
+                        upcoming_url = await _scoreboard_call(
+                            (next_date - timedelta(days=1)).strftime("%Y%m%d"),
+                            next_date.strftime("%Y%m%d"),
                         )
-                        return values
+                        if upcoming_url:
+                            used_url = upcoming_url
         except Exception as e:  # pylint: disable=broad-exception-caught
-            _LOGGER.debug("%s: Team schedule API call failed: %s", sensor_name, e)
+            _LOGGER.debug("%s: Team info call failed: %s", sensor_name, e)
+
+        if all_events:
+            self.api_url = used_url or scoreboard_base
+            values = await self.async_update_values(
+                config, hass, {"events": all_events}, lang
+            )
+            if values["state"] != "NOT_FOUND":
+                return values
 
         return prev_values
 

--- a/custom_components/teamtracker/__init__.py
+++ b/custom_components/teamtracker/__init__.py
@@ -231,6 +231,7 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
     data_cache = {}
     last_update = {}
     c_cache = {}
+    all_team_cache = {}  # {"{sport}:{league}:{team_id}": {needs_fallback, next_events, id_to_competition, expires}}
 
     def __init__(self, hass, config, entry: ConfigEntry=None):
         """Initialize."""
@@ -373,6 +374,21 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
                 return values
 
         #
+        #  Fast path for 'all' league teams known to need the fallback:
+        #  the primary scoreboard never finds them, so skip it entirely and
+        #  go straight to targeted calls using the cached game date.
+        #
+        if league_path == "all":
+            tkey = f"{sport_path}:{league_path}:{self.team_id}"
+            tcached = TeamTrackerDataUpdateCoordinator.all_team_cache.get(tkey)
+            if tcached and date.today() <= tcached["expires"] and tcached.get("needs_fallback"):
+                values = await self.async_update_values(config, hass, {}, lang)
+                values = await self.async_try_team_schedule(config, hass, lang, values)
+                if values["state"] != "NOT_FOUND":
+                    return values
+                # all_team_cache was invalidated inside; fall through to full flow
+
+        #
         #  Call the API
         #  Get the language based on the locale
         #    Then override it if there is a value in frontend_storage for the selected language
@@ -428,42 +444,67 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
         headers = {"User-Agent": USER_AGENT, "Accept": "application/ld+json"}
         session = await self._get_session()
 
-        # Build event_id → competition name mapping from team info and schedule.
-        # These endpoints carry season.displayName; the scoreboard does not.
-        id_to_competition = {}
+        # Check all_team_cache to avoid repeating the team info and schedule API
+        # calls on every update tick (especially during live games at 5-second
+        # intervals).  The cache expires after the next game's date passes, which
+        # triggers re-discovery so the competition name and game date stay current.
+        cache_key = f"{sport_path}:{league_path}:{team_id}"
+        today = date.today()
+        cached = TeamTrackerDataUpdateCoordinator.all_team_cache.get(cache_key)
+        cache_valid = cached is not None and today <= cached["expires"]
 
-        try:
-            async with session.get(team_url, headers=headers) as r:
-                _LOGGER.debug(
-                    "%s: Team info call for '%s' from %s",
-                    sensor_name, team_id, team_url,
-                )
-                if r.status == 200:
-                    team_data = await r.json()
-                    next_events = team_data.get("team", {}).get("nextEvent", [])
-                    for ne in next_events:
-                        display = ne.get("season", {}).get("displayName")
-                        if ne.get("id") and display:
-                            id_to_competition[ne["id"]] = display
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            _LOGGER.debug("%s: Team info call failed: %s", sensor_name, e)
+        if cache_valid:
+            id_to_competition = cached["id_to_competition"]
+            next_events = cached["next_events"]
+            _LOGGER.debug("%s: all_team_cache hit for '%s'", sensor_name, team_id)
+        else:
+            # Full discovery: build event_id → competition name mapping from the
+            # team info and schedule endpoints, which carry season.displayName.
+            # The scoreboard does not include this field.
+            id_to_competition = {}
             next_events = []
 
-        try:
-            schedule_url = team_url + "/schedule"
-            async with session.get(schedule_url, headers=headers) as r:
-                _LOGGER.debug(
-                    "%s: Team schedule call for '%s' from %s",
-                    sensor_name, team_id, schedule_url,
-                )
-                if r.status == 200:
-                    sched_data = await r.json()
-                    for e in sched_data.get("events", []):
-                        display = e.get("season", {}).get("displayName")
-                        if e.get("id") and display:
-                            id_to_competition[e["id"]] = display
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            _LOGGER.debug("%s: Team schedule call failed: %s", sensor_name, e)
+            try:
+                async with session.get(team_url, headers=headers) as r:
+                    _LOGGER.debug(
+                        "%s: Team info call for '%s' from %s",
+                        sensor_name, team_id, team_url,
+                    )
+                    if r.status == 200:
+                        team_data = await r.json()
+                        next_events = team_data.get("team", {}).get("nextEvent", [])
+                        for ne in next_events:
+                            display = ne.get("season", {}).get("displayName")
+                            if ne.get("id") and display:
+                                id_to_competition[ne["id"]] = display
+            except Exception as e:  # pylint: disable=broad-exception-caught
+                _LOGGER.debug("%s: Team info call failed: %s", sensor_name, e)
+
+            try:
+                schedule_url = team_url + "/schedule"
+                async with session.get(schedule_url, headers=headers) as r:
+                    _LOGGER.debug(
+                        "%s: Team schedule call for '%s' from %s",
+                        sensor_name, team_id, schedule_url,
+                    )
+                    if r.status == 200:
+                        sched_data = await r.json()
+                        for e in sched_data.get("events", []):
+                            display = e.get("season", {}).get("displayName")
+                            if e.get("id") and display:
+                                id_to_competition[e["id"]] = display
+            except Exception as e:  # pylint: disable=broad-exception-caught
+                _LOGGER.debug("%s: Team schedule call failed: %s", sensor_name, e)
+
+            next_game_date = (
+                date.fromisoformat(next_events[0]["date"][:10]) if next_events else None
+            )
+            TeamTrackerDataUpdateCoordinator.all_team_cache[cache_key] = {
+                "needs_fallback": prev_values["state"] == "NOT_FOUND",
+                "next_events": next_events,
+                "id_to_competition": id_to_competition,
+                "expires": next_game_date or today,
+            }
 
         values = prev_values
 
@@ -529,6 +570,15 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
                 values = await self.async_update_values(
                     config, hass, {"events": all_events}, lang
                 )
+
+            # Targeted calls returned NOT_FOUND — the cached game date is stale.
+            # Invalidate so the next tick does a full re-discovery.
+            if values["state"] == "NOT_FOUND" and cache_valid:
+                _LOGGER.debug(
+                    "%s: Invalidating stale all_team_cache for '%s'",
+                    sensor_name, team_id,
+                )
+                del TeamTrackerDataUpdateCoordinator.all_team_cache[cache_key]
 
         # Enrich league name from the competition the matched game belongs to.
         # Extract the game ID from the event URL (format: .../gameId/XXXXXXX/...)

--- a/custom_components/teamtracker/__init__.py
+++ b/custom_components/teamtracker/__init__.py
@@ -6,6 +6,8 @@ import locale
 import logging
 import os
 
+import re
+
 import aiofiles
 import aiohttp
 import arrow
@@ -362,7 +364,7 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
             if now < expiration:
                 data = self.data_cache[key]
                 values = await self.async_update_values(config, hass, data, lang)
-                if values["state"] == "NOT_FOUND" and league_path == "all":
+                if league_path == "all":
                     values = await self.async_try_team_schedule(config, hass, lang, values)
                 if values["api_message"]:
                     values["api_message"] = "Cached data: " + values["api_message"]
@@ -379,7 +381,7 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
 
         data, file_override = await self.async_call_api(config, hass, lang)
         values = await self.async_update_values(config, hass, data, lang)
-        if values["state"] == "NOT_FOUND" and league_path == "all" and not file_override:
+        if league_path == "all" and not file_override:
             values = await self.async_try_team_schedule(config, hass, lang, values)
         self.data_cache[key] = data
         self.last_update[key] = values["last_update"]
@@ -402,15 +404,16 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
         return values
 
     async def async_try_team_schedule(self, config, hass, lang, prev_values) -> dict:
-        """Fallback for 'all' league: make targeted scoreboard calls so returned data
-        is identical in format to the primary scoreboard path.
+        """Handle 'all' league enrichment and fallback.
 
-        Two narrow-window calls are made and their events combined:
-          1. yesterday–today: captures any POST/IN game (few events, no limit issue)
-          2. day-before–day-of next game (from nextEvent): captures the PRE game
-
-        The existing 18-hour transition rule then handles POST→PRE naturally,
-        matching the behaviour of teams found in the primary scoreboard.
+        Always runs for league_path=all to:
+          1. Resolve the active competition name from the team info and schedule
+             endpoints (which carry season.displayName) and store it in
+             values["league"], replacing the user-configured placeholder.
+          2. When the team was not found in the broad primary scoreboard (due to
+             the 50-event limit cutting off lesser-followed leagues), fall back to
+             two narrow targeted scoreboard calls so the data format stays
+             identical to the primary path (logos, odds, TV network included).
         """
 
         team_id = self.team_id
@@ -425,47 +428,10 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
         headers = {"User-Agent": USER_AGENT, "Accept": "application/ld+json"}
         session = await self._get_session()
 
-        all_events = []
-        seen_ids = set()
+        # Build event_id → competition name mapping from team info and schedule.
+        # These endpoints carry season.displayName; the scoreboard does not.
+        id_to_competition = {}
 
-        def _merge(new_events):
-            for e in new_events:
-                eid = e.get("id")
-                if eid not in seen_ids:
-                    seen_ids.add(eid)
-                    all_events.append(e)
-
-        async def _scoreboard_call(d1_str, d2_str):
-            url = (
-                scoreboard_base
-                + "?lang=" + lang[:2]
-                + "&limit=" + str(API_LIMIT)
-                + "&dates=" + d1_str + "-" + d2_str
-            )
-            try:
-                async with session.get(url, headers=headers) as r:
-                    _LOGGER.debug(
-                        "%s: Targeted scoreboard call for '%s' from %s",
-                        sensor_name, team_id, url,
-                    )
-                    if r.status == 200:
-                        data = await r.json()
-                        if data and "events" in data:
-                            _merge(data["events"])
-                            return url
-            except Exception as e:  # pylint: disable=broad-exception-caught
-                _LOGGER.debug("%s: Targeted scoreboard call failed: %s", sensor_name, e)
-            return None
-
-        # Call 1: recent window (yesterday–today) — catches POST/IN games
-        today = date.today()
-        used_url = await _scoreboard_call(
-            (today - timedelta(days=1)).strftime("%Y%m%d"),
-            today.strftime("%Y%m%d"),
-        )
-
-        # Call 2: upcoming game window — catches the PRE game.
-        # Use nextEvent to find the exact game date so the window stays narrow.
         try:
             async with session.get(team_url, headers=headers) as r:
                 _LOGGER.debug(
@@ -475,26 +441,107 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
                 if r.status == 200:
                     team_data = await r.json()
                     next_events = team_data.get("team", {}).get("nextEvent", [])
-                    if next_events:
-                        next_date = datetime.fromisoformat(
-                            next_events[0]["date"][:10]
-                        ).date()
-                        upcoming_url = await _scoreboard_call(
-                            (next_date - timedelta(days=1)).strftime("%Y%m%d"),
-                            next_date.strftime("%Y%m%d"),
-                        )
-                        if upcoming_url:
-                            used_url = upcoming_url
+                    for ne in next_events:
+                        display = ne.get("season", {}).get("displayName")
+                        if ne.get("id") and display:
+                            id_to_competition[ne["id"]] = display
         except Exception as e:  # pylint: disable=broad-exception-caught
             _LOGGER.debug("%s: Team info call failed: %s", sensor_name, e)
+            next_events = []
 
-        if all_events:
-            self.api_url = used_url or scoreboard_base
-            values = await self.async_update_values(
-                config, hass, {"events": all_events}, lang
+        try:
+            schedule_url = team_url + "/schedule"
+            async with session.get(schedule_url, headers=headers) as r:
+                _LOGGER.debug(
+                    "%s: Team schedule call for '%s' from %s",
+                    sensor_name, team_id, schedule_url,
+                )
+                if r.status == 200:
+                    sched_data = await r.json()
+                    for e in sched_data.get("events", []):
+                        display = e.get("season", {}).get("displayName")
+                        if e.get("id") and display:
+                            id_to_competition[e["id"]] = display
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            _LOGGER.debug("%s: Team schedule call failed: %s", sensor_name, e)
+
+        values = prev_values
+
+        # If the primary scoreboard already found the team, just enrich league name.
+        if prev_values["state"] != "NOT_FOUND":
+            values = prev_values
+        else:
+            # Primary scoreboard missed the team (50-event limit). Fall back to
+            # targeted narrow-window scoreboard calls that keep event count low.
+            all_events = []
+            seen_ids = set()
+
+            def _merge(new_events):
+                for e in new_events:
+                    eid = e.get("id")
+                    if eid not in seen_ids:
+                        seen_ids.add(eid)
+                        all_events.append(e)
+
+            async def _scoreboard_call(d1_str, d2_str):
+                url = (
+                    scoreboard_base
+                    + "?lang=" + lang[:2]
+                    + "&limit=" + str(API_LIMIT)
+                    + "&dates=" + d1_str + "-" + d2_str
+                )
+                try:
+                    async with session.get(url, headers=headers) as r:
+                        _LOGGER.debug(
+                            "%s: Targeted scoreboard call for '%s' from %s",
+                            sensor_name, team_id, url,
+                        )
+                        if r.status == 200:
+                            data = await r.json()
+                            if data and "events" in data:
+                                _merge(data["events"])
+                                return url
+                except Exception as e:  # pylint: disable=broad-exception-caught
+                    _LOGGER.debug(
+                        "%s: Targeted scoreboard call failed: %s", sensor_name, e
+                    )
+                return None
+
+            today = date.today()
+            used_url = await _scoreboard_call(
+                (today - timedelta(days=1)).strftime("%Y%m%d"),
+                today.strftime("%Y%m%d"),
             )
-            if values["state"] != "NOT_FOUND":
-                return values
+
+            if next_events:
+                next_date = datetime.fromisoformat(
+                    next_events[0]["date"][:10]
+                ).date()
+                upcoming_url = await _scoreboard_call(
+                    (next_date - timedelta(days=1)).strftime("%Y%m%d"),
+                    next_date.strftime("%Y%m%d"),
+                )
+                if upcoming_url:
+                    used_url = upcoming_url
+
+            if all_events:
+                self.api_url = used_url or scoreboard_base
+                values = await self.async_update_values(
+                    config, hass, {"events": all_events}, lang
+                )
+
+        # Enrich league name from the competition the matched game belongs to.
+        # Extract the game ID from the event URL (format: .../gameId/XXXXXXX/...)
+        event_url = values.get("event_url", "") or ""
+        match = re.search(r"/gameId/(\d+)/", event_url)
+        if match:
+            game_id = match.group(1)
+            competition = id_to_competition.get(game_id)
+            if competition:
+                values["league"] = re.sub(r"^\d{4}(-\d{2})?\s+", "", competition)
+
+        if values["state"] != "NOT_FOUND":
+            return values
 
         return prev_values
 

--- a/custom_components/teamtracker/__init__.py
+++ b/custom_components/teamtracker/__init__.py
@@ -550,11 +550,20 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
                 )
             return None
 
-        # Use UTC date so games played late local time (e.g. 11 PM PDT =
-        # next day UTC) are included in the recent window.
         today_utc = datetime.now(timezone.utc).date()
+        yesterday_utc = today_utc - timedelta(days=1)
+        day_before_yesterday = today_utc - timedelta(days=2)
+
+        # Always check two recent windows. ESPN categorizes games under a
+        # different date window than the UTC kickoff time from the schedule
+        # endpoint (e.g. a March 17 PDT game appears in 20260317-20260318, not
+        # 20260318-20260319), so a single window can miss recent results.
+        await _scoreboard_call(
+            day_before_yesterday.strftime("%Y%m%d"),
+            yesterday_utc.strftime("%Y%m%d"),
+        )
         used_url = await _scoreboard_call(
-            (today_utc - timedelta(days=1)).strftime("%Y%m%d"),
+            yesterday_utc.strftime("%Y%m%d"),
             today_utc.strftime("%Y%m%d"),
         )
 
@@ -562,8 +571,8 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
             next_date = datetime.fromisoformat(
                 next_events[0]["date"][:10]
             ).date()
-            # Only make the upcoming call if its window differs from the recent window
-            # (e.g. avoid a duplicate call when the next game is today UTC).
+            # Only make the upcoming call if its window differs from the recent
+            # window (avoid a duplicate when the next game is today UTC).
             if next_date > today_utc:
                 upcoming_url = await _scoreboard_call(
                     (next_date - timedelta(days=1)).strftime("%Y%m%d"),

--- a/custom_components/teamtracker/__init__.py
+++ b/custom_components/teamtracker/__init__.py
@@ -163,8 +163,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if entry.entry_id in hass.data[DOMAIN]:
         coordinator = hass.data[DOMAIN][entry.entry_id].get(COORDINATOR)
         if coordinator:
-            if hasattr(coordinator, "async_unload"):
-                await coordinator.async_unload()
+            if hasattr(coordinator, "async_shutdown"):
+                await coordinator.async_shutdown()
                 
     # Unload platforms
     unload_ok = all(
@@ -231,7 +231,7 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
     data_cache = {}
     last_update = {}
     c_cache = {}
-    all_team_cache = {}  # {"{sport}:{league}:{team_id}": {needs_fallback, next_events, id_to_competition, expires}}
+    all_team_cache = {}  # {"{sport}:{league}:{team_id}": {next_game_date, id_to_competition, expires}}
 
     def __init__(self, hass, config, entry: ConfigEntry=None):
         """Initialize."""
@@ -307,6 +307,8 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
 
         lang = self.get_lang()
         key = sport_path + ":" + league_path + ":" + conference_id + ":" + lang
+        if league_path == "all":
+            key += ":" + team_id
 
         if key in TeamTrackerDataUpdateCoordinator.data_cache:
             del TeamTrackerDataUpdateCoordinator.data_cache[key]
@@ -351,7 +353,11 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
 
         lang = self.get_lang()
 
+        # For "all" leagues, include team_id in cache key since each team
+        # uses different narrow date windows for the scoreboard call.
         key = sport_path + ":" + league_path + ":" + conference_id + ":" + lang
+        if league_path == "all":
+            key += ":" + self.team_id
 
         #
         #  Use cache if not expired
@@ -366,7 +372,7 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
                 data = self.data_cache[key]
                 values = await self.async_update_values(config, hass, data, lang)
                 if league_path == "all":
-                    values = await self.async_try_team_schedule(config, hass, lang, values)
+                    values = await self._enrich_league_name(values)
                 if values["api_message"]:
                     values["api_message"] = "Cached data: " + values["api_message"]
                 else:
@@ -374,32 +380,69 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
                 return values
 
         #
-        #  Fast path for 'all' league teams known to need the fallback:
-        #  the primary scoreboard never finds them, so skip it entirely and
-        #  go straight to targeted calls using the cached game date.
+        #  Call the API
+        #  For "all" leagues, use narrow dates from team schedule to stay
+        #  within the 50-event API limit across all competitions.
+        #  For other leagues, use the default date computation.
         #
         if league_path == "all":
-            tkey = f"{sport_path}:{league_path}:{self.team_id}"
-            tcached = TeamTrackerDataUpdateCoordinator.all_team_cache.get(tkey)
-            if tcached and date.today() <= tcached["expires"] and tcached.get("needs_fallback"):
-                values = await self.async_update_values(config, hass, {}, lang)
-                values = await self.async_try_team_schedule(config, hass, lang, values)
-                if values["state"] != "NOT_FOUND":
-                    return values
-                # all_team_cache was invalidated inside; fall through to full flow
+            schedule_info = await self.async_get_team_schedule(lang)
+            next_game_date = schedule_info.get("next_game_date") if schedule_info else None
 
-        #
-        #  Call the API
-        #  Get the language based on the locale
-        #    Then override it if there is a value in frontend_storage for the selected language
-        #      (it usually takes about a minute after reboot for frontend_storage to be populated)
-        #
+            today_utc = datetime.now(timezone.utc).date()
+            day_before_yesterday = today_utc - timedelta(days=2)
 
-        data, file_override = await self.async_call_api(config, hass, lang)
-        values = await self.async_update_values(config, hass, data, lang)
-        if league_path == "all" and not file_override:
-            values = await self.async_try_team_schedule(config, hass, lang, values)
-        self.data_cache[key] = data
+            # Narrow window: cover recent results and upcoming game if within 7 days
+            d1 = day_before_yesterday.strftime("%Y%m%d")
+            if next_game_date and next_game_date <= today_utc + timedelta(days=7):
+                d2 = next_game_date.strftime("%Y%m%d")
+            else:
+                d2 = today_utc.strftime("%Y%m%d")
+
+            _LOGGER.debug(
+                "%s: All-league scoreboard call 1/1 dates=%s-%s (next_game=%s)",
+                sensor_name, d1, d2,
+                next_game_date.isoformat() if next_game_date else "unknown",
+            )
+            scoreboard_calls = 1
+            data, file_override = await self.async_call_api(
+                config, hass, lang, d1_override=d1, d2_override=d2
+            )
+            values = await self.async_update_values(config, hass, data, lang)
+
+            # If not found in the recent window and next game is beyond it,
+            # try a narrow call around the next game date.
+            if (values["state"] == "NOT_FOUND" and not file_override
+                    and next_game_date and next_game_date > today_utc):
+                nd1 = (next_game_date - timedelta(days=1)).strftime("%Y%m%d")
+                nd2 = next_game_date.strftime("%Y%m%d")
+                if nd1 != d1 or nd2 != d2:  # avoid duplicate call
+                    _LOGGER.debug(
+                        "%s: All-league scoreboard call 2/2 dates=%s-%s (fallback to next game)",
+                        sensor_name, nd1, nd2,
+                    )
+                    scoreboard_calls = 2
+                    data2, _ = await self.async_call_api(
+                        config, hass, lang, d1_override=nd1, d2_override=nd2
+                    )
+                    values2 = await self.async_update_values(config, hass, data2, lang)
+                    if values2["state"] != "NOT_FOUND":
+                        data = data2
+                        values = values2
+
+            values = await self._enrich_league_name(values)
+            msg = values.get("api_message") or ""
+            values["api_message"] = (
+                f"All-league: {scoreboard_calls} scoreboard call(s), "
+                f"dates={d1}-{d2}"
+                + (f" | {msg}" if msg else "")
+            )
+        else:
+            data, file_override = await self.async_call_api(config, hass, lang)
+            values = await self.async_update_values(config, hass, data, lang)
+
+        if data is not None:
+            self.data_cache[key] = data
         self.last_update[key] = values["last_update"]
 
         if file_override:
@@ -419,204 +462,101 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
                     )
         return values
 
-    async def async_try_team_schedule(self, config, hass, lang, prev_values) -> dict:
-        """Handle 'all' league enrichment and fallback.
+    async def async_get_team_schedule(self, lang):
+        """Fetch team schedule info for 'all' league date computation.
 
-        Always runs for league_path=all to:
-          1. Resolve the active competition name from the team info and schedule
-             endpoints (which carry season.displayName) and store it in
-             values["league"], replacing the user-configured placeholder.
-          2. When the team was not found in the broad primary scoreboard (due to
-             the 50-event limit cutting off lesser-followed leagues), fall back to
-             two narrow targeted scoreboard calls so the data format stays
-             identical to the primary path (logos, odds, TV network included).
+        Calls the team info and schedule endpoints to discover the next game
+        date and build an event_id → competition name mapping.  Results are
+        cached in all_team_cache until the next game date passes.
         """
-
         team_id = self.team_id
         sport_path = self.sport_path
         league_path = self.league_path
         sensor_name = self.name
 
-        scoreboard_base = URL_HEAD + sport_path + "/" + league_path + URL_TAIL
-        team_url = (
-            URL_HEAD + sport_path + "/" + league_path + "/teams/" + team_id
-        )
-        headers = {"User-Agent": USER_AGENT, "Accept": "application/ld+json"}
-        session = await self._get_session()
-
-        # Check all_team_cache to avoid repeating the team info and schedule API
-        # calls on every update tick (especially during live games at 5-second
-        # intervals).  The cache expires after the next game's date passes, which
-        # triggers re-discovery so the competition name and game date stay current.
         cache_key = f"{sport_path}:{league_path}:{team_id}"
         today = date.today()
         cached = TeamTrackerDataUpdateCoordinator.all_team_cache.get(cache_key)
-        cache_valid = cached is not None and today <= cached["expires"]
 
-        if cache_valid:
-            id_to_competition = cached["id_to_competition"]
-            next_events = cached["next_events"]
-            needs_fallback = cached["needs_fallback"]
+        if cached is not None and today <= cached["expires"]:
             _LOGGER.debug("%s: all_team_cache hit for '%s'", sensor_name, team_id)
-        else:
-            # Full discovery: build event_id → competition name mapping from the
-            # team info and schedule endpoints, which carry season.displayName.
-            # The scoreboard does not include this field.
-            id_to_competition = {}
-            next_events = []
+            return cached
 
-            try:
-                async with session.get(team_url, headers=headers) as r:
-                    _LOGGER.debug(
-                        "%s: Team info call for '%s' from %s",
-                        sensor_name, team_id, team_url,
-                    )
-                    if r.status == 200:
-                        team_data = await r.json()
-                        next_events = team_data.get("team", {}).get("nextEvent", [])
-                        for ne in next_events:
-                            display = ne.get("season", {}).get("displayName")
-                            if ne.get("id") and display:
-                                id_to_competition[ne["id"]] = display
-            except Exception as e:  # pylint: disable=broad-exception-caught
-                _LOGGER.debug("%s: Team info call failed: %s", sensor_name, e)
+        team_url = URL_HEAD + sport_path + "/" + league_path + "/teams/" + team_id
+        headers = {"User-Agent": USER_AGENT, "Accept": "application/ld+json"}
+        session = await self._get_session()
 
-            try:
-                schedule_url = team_url + "/schedule"
-                async with session.get(schedule_url, headers=headers) as r:
-                    _LOGGER.debug(
-                        "%s: Team schedule call for '%s' from %s",
-                        sensor_name, team_id, schedule_url,
-                    )
-                    if r.status == 200:
-                        sched_data = await r.json()
-                        for e in sched_data.get("events", []):
-                            display = e.get("season", {}).get("displayName")
-                            if e.get("id") and display:
-                                id_to_competition[e["id"]] = display
-            except Exception as e:  # pylint: disable=broad-exception-caught
-                _LOGGER.debug("%s: Team schedule call failed: %s", sensor_name, e)
+        id_to_competition = {}
+        next_events = []
 
-            next_game_date = (
-                date.fromisoformat(next_events[0]["date"][:10]) if next_events else None
-            )
-            needs_fallback = prev_values["state"] == "NOT_FOUND"
-            TeamTrackerDataUpdateCoordinator.all_team_cache[cache_key] = {
-                "needs_fallback": needs_fallback,
-                "next_events": next_events,
-                "id_to_competition": id_to_competition,
-                "expires": next_game_date or today,
-            }
-
-        # Always run targeted narrow-window scoreboard calls for league_path == all.
-        # The primary scoreboard (50-event limit) may return a far-future game
-        # while a live or closer game exists in another competition.  Targeted
-        # calls use tight date windows so they reliably surface the current game.
-        # If targeted calls find a match it takes priority; otherwise we keep
-        # whatever the primary scoreboard found.
-        values = prev_values  # default: keep primary result
-
-        all_events = []
-        seen_ids = set()
-
-        def _merge(new_events):
-            for e in new_events:
-                eid = e.get("id")
-                if eid not in seen_ids:
-                    seen_ids.add(eid)
-                    all_events.append(e)
-
-        async def _scoreboard_call(d1_str, d2_str):
-            url = (
-                scoreboard_base
-                + "?lang=" + lang[:2]
-                + "&limit=" + str(API_LIMIT)
-                + "&dates=" + d1_str + "-" + d2_str
-            )
-            try:
-                async with session.get(url, headers=headers) as r:
-                    _LOGGER.debug(
-                        "%s: Targeted scoreboard call for '%s' from %s",
-                        sensor_name, team_id, url,
-                    )
-                    if r.status == 200:
-                        data = await r.json()
-                        if data and "events" in data:
-                            _merge(data["events"])
-                            return url
-            except Exception as e:  # pylint: disable=broad-exception-caught
+        try:
+            async with session.get(team_url, headers=headers) as r:
                 _LOGGER.debug(
-                    "%s: Targeted scoreboard call failed: %s", sensor_name, e
+                    "%s: Team info call for '%s' from %s",
+                    sensor_name, team_id, team_url,
                 )
-            return None
+                if r.status == 200:
+                    team_data = await r.json()
+                    next_events = team_data.get("team", {}).get("nextEvent", [])
+                    for ne in next_events:
+                        display = ne.get("season", {}).get("displayName")
+                        if ne.get("id") and display:
+                            id_to_competition[ne["id"]] = display
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            _LOGGER.debug("%s: Team info call failed: %s", sensor_name, e)
 
-        today_utc = datetime.now(timezone.utc).date()
-        yesterday_utc = today_utc - timedelta(days=1)
-        day_before_yesterday = today_utc - timedelta(days=2)
-
-        # Always check two recent windows. ESPN categorizes games under a
-        # different date window than the UTC kickoff time from the schedule
-        # endpoint (e.g. a March 17 PDT game appears in 20260317-20260318, not
-        # 20260318-20260319), so a single window can miss recent results.
-        await _scoreboard_call(
-            day_before_yesterday.strftime("%Y%m%d"),
-            yesterday_utc.strftime("%Y%m%d"),
-        )
-        used_url = await _scoreboard_call(
-            yesterday_utc.strftime("%Y%m%d"),
-            today_utc.strftime("%Y%m%d"),
-        )
-
-        if next_events:
-            next_date = datetime.fromisoformat(
-                next_events[0]["date"][:10]
-            ).date()
-            # Only make the upcoming call if its window differs from the recent
-            # window (avoid a duplicate when the next game is today UTC).
-            if next_date > today_utc:
-                upcoming_url = await _scoreboard_call(
-                    (next_date - timedelta(days=1)).strftime("%Y%m%d"),
-                    next_date.strftime("%Y%m%d"),
+        try:
+            schedule_url = team_url + "/schedule"
+            async with session.get(schedule_url, headers=headers) as r:
+                _LOGGER.debug(
+                    "%s: Team schedule call for '%s' from %s",
+                    sensor_name, team_id, schedule_url,
                 )
-                if upcoming_url:
-                    used_url = upcoming_url
+                if r.status == 200:
+                    sched_data = await r.json()
+                    for e in sched_data.get("events", []):
+                        display = e.get("season", {}).get("displayName")
+                        if e.get("id") and display:
+                            id_to_competition[e["id"]] = display
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            _LOGGER.debug("%s: Team schedule call failed: %s", sensor_name, e)
 
-        if all_events:
-            self.api_url = used_url or scoreboard_base
-            targeted_values = await self.async_update_values(
-                config, hass, {"events": all_events}, lang
-            )
-            if targeted_values["state"] != "NOT_FOUND":
-                values = targeted_values
+        next_game_date = (
+            date.fromisoformat(next_events[0]["date"][:10]) if next_events else None
+        )
 
-        # Targeted calls returned NOT_FOUND and primary also has nothing —
-        # the cached game date is stale.  Invalidate for re-discovery next tick.
-        if values["state"] == "NOT_FOUND" and cache_valid:
-            _LOGGER.debug(
-                "%s: Invalidating stale all_team_cache for '%s'",
-                sensor_name, team_id,
-            )
-            del TeamTrackerDataUpdateCoordinator.all_team_cache[cache_key]
+        result = {
+            "next_game_date": next_game_date,
+            "id_to_competition": id_to_competition,
+            "expires": next_game_date or today,
+        }
+        TeamTrackerDataUpdateCoordinator.all_team_cache[cache_key] = result
+        return result
 
-        # Enrich league name from the competition the matched game belongs to.
-        # Extract the game ID from the event URL (format: .../gameId/XXXXXXX/...)
+    async def _enrich_league_name(self, values):
+        """Set league_name from the competition the matched game belongs to."""
+        cache_key = f"{self.sport_path}:{self.league_path}:{self.team_id}"
+        cached = TeamTrackerDataUpdateCoordinator.all_team_cache.get(cache_key)
+        if not cached:
+            return values
+
+        id_to_competition = cached.get("id_to_competition", {})
         event_url = values.get("event_url", "") or ""
         match = re.search(r"/gameId/(\d+)", event_url)
         if match:
             game_id = match.group(1)
             competition = id_to_competition.get(game_id)
             if competition:
-                values["league"] = re.sub(r"^\d{4}(-\d{2})?\s+", "", competition)
+                name = re.sub(r"^\d{4}(-\d{2})?\s+", "", competition)
+                values["league_name"] = name
+                values["league"] = name
 
-        if values["state"] != "NOT_FOUND":
-            return values
-
-        return prev_values
+        return values
 
     #
     #  Call the API (or file override) and get the data returned by it
     #
-    async def async_call_api(self, config, hass, lang) -> dict:
+    async def async_call_api(self, config, hass, lang, d1_override=None, d2_override=None) -> dict:
         """Query API for status."""
 
         headers = {"User-Agent": USER_AGENT, "Accept": "application/ld+json"}
@@ -630,7 +570,9 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
 
         url_parms = "?lang=" + lang[:2] + "&limit=" + str(API_LIMIT)
 
-        if sport_path not in ("tennis", "baseball"):
+        if d1_override is not None and d2_override is not None:
+            url_parms = url_parms + "&dates=" + d1_override + "-" + d2_override
+        elif sport_path not in ("tennis", "baseball"):
             d1 = (date.today() - timedelta(days=1)).strftime("%Y%m%d")
             if league_path == "all":
                 d2 = (date.today() + timedelta(days=5)).strftime("%Y%m%d")
@@ -690,7 +632,9 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
             )
             
             # First fallback - without date constraint
-            if num_events == 0:
+            # Skip fallbacks when date overrides are provided (e.g. "all" league
+            # narrow-window calls) — the caller handles retry with different dates.
+            if num_events == 0 and d1_override is None:
                 url_parms = "?lang=" + lang[:2]
                 if self.conference_id:
                     url_parms = url_parms + "&groups=" + self.conference_id
@@ -734,7 +678,7 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
                 )
 
             # Second fallback - without language
-            if num_events == 0:
+            if num_events == 0 and d1_override is None:
                 url_parms = ""
                 if self.conference_id:
                     url_parms = url_parms + "?groups=" + self.conference_id

--- a/custom_components/teamtracker/clear_values.py
+++ b/custom_components/teamtracker/clear_values.py
@@ -12,6 +12,7 @@ async def async_clear_values() -> dict:
         "league": None,
         "league_path": None,
         "league_logo": None,
+        "league_name": None,
         "season": None,
         "team_abbr": None,
         "opponent_abbr": None,

--- a/custom_components/teamtracker/const.py
+++ b/custom_components/teamtracker/const.py
@@ -195,7 +195,7 @@ SERVICE_NAME_CALL_API = "call_api"
 
 # Misc
 TEAM_ID = ""
-VERSION = "v0.14.15"
+VERSION = "v0.15.0"
 ISSUE_URL = "https://github.com/vasqued2/ha-teamtracker"
 DOMAIN = "teamtracker"
 ATTRIBUTION = "Data provided by ESPN"

--- a/custom_components/teamtracker/event.py
+++ b/custom_components/teamtracker/event.py
@@ -29,6 +29,9 @@ async def async_process_event(
     values["league_logo"] = await async_get_value(
         data, "leagues", 0, "logos", 0, "href", default=DEFAULT_LOGO
     )
+    values["league_name"] = await async_get_value(
+        data, "leagues", 0, "name", default=""
+    )
 
     events = data.get("events", [])
     limit_hit = len(events) == API_LIMIT
@@ -477,10 +480,13 @@ async def async_process_competition_dates(
     competition_date_str = await async_get_value(
         competition, "date", default=(await async_get_value(event, "date"))
     )
-    competition_date = datetime.strptime(
-        competition_date_str, "%Y-%m-%dT%H:%Mz"
-    )
-    last_date = max(last_date, competition_date)
-    first_date = min(first_date, competition_date)
+    try:
+        competition_date = datetime.fromisoformat(
+            str(competition_date_str).replace("Z", "+00:00")
+        ).replace(tzinfo=None)
+        last_date = max(last_date, competition_date)
+        first_date = min(first_date, competition_date)
+    except (ValueError, TypeError):
+        pass
 
     return first_date, last_date

--- a/custom_components/teamtracker/event.py
+++ b/custom_components/teamtracker/event.py
@@ -30,11 +30,12 @@ async def async_process_event(
         data, "leagues", 0, "logos", 0, "href", default=DEFAULT_LOGO
     )
 
-    limit_hit = len(data["events"]) == API_LIMIT
+    events = data.get("events", [])
+    limit_hit = len(events) == API_LIMIT
     first_date = datetime(9999, 12, 31, 1, 0, 0)
     last_date = datetime(1900, 1, 31, 1, 0, 0)
 
-    for event in data["events"]:
+    for event in events:
         event_state = "NOT_FOUND"
 
         grouping_index = -1

--- a/custom_components/teamtracker/sensor.py
+++ b/custom_components/teamtracker/sensor.py
@@ -201,6 +201,7 @@ class TeamTrackerScoresSensor(CoordinatorEntity):
         self._league = None
         self._league_path = None
         self._league_logo = None
+        self._league_name = None
         self._season = None
         self._team_abbr = None
         self._opponent_abbr = None
@@ -314,6 +315,7 @@ class TeamTrackerScoresSensor(CoordinatorEntity):
         attrs["league"] = self.coordinator.data["league"]
         attrs["league_path"] = self.coordinator.data["league_path"]
         attrs["league_logo"] = self.coordinator.data["league_logo"]
+        attrs["league_name"] = self.coordinator.data["league_name"]
         attrs["season"] = self.coordinator.data["season"]
         attrs["team_abbr"] = self.coordinator.data["team_abbr"]
         attrs["opponent_abbr"] = self.coordinator.data["opponent_abbr"]

--- a/custom_components/teamtracker/set_baseball.py
+++ b/custom_components/teamtracker/set_baseball.py
@@ -11,6 +11,8 @@ async def async_set_baseball_values(
     new_values["clock"] = await async_get_value(
         event, "status", "type", "detail"
     )  # Inning
+    if not new_values["clock"]:
+        new_values["clock"] = ""
     if new_values["clock"][:3].lower() in ["bot", "mid"]:
         if new_values["team_homeaway"] in [
             "home"

--- a/tests/tt/results/test_tt_all_test01.json
+++ b/tests/tt/results/test_tt_all_test01.json
@@ -4,6 +4,7 @@
     "league": "MLB",
     "league_path": "mlb",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": "regular-season",
     "team_abbr": "MIA",
     "opponent_abbr": "PHI",

--- a/tests/tt/results/test_tt_all_test02.json
+++ b/tests/tt/results/test_tt_all_test02.json
@@ -4,6 +4,7 @@
     "league": "MLB",
     "league_path": "mlb",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": "regular-season",
     "team_abbr": "MIL",
     "opponent_abbr": "SF",

--- a/tests/tt/results/test_tt_all_test03.json
+++ b/tests/tt/results/test_tt_all_test03.json
@@ -4,6 +4,7 @@
     "league": "MLB",
     "league_path": "mlb",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": "regular-season",
     "team_abbr": "CIN",
     "opponent_abbr": "CHC",

--- a/tests/tt/results/test_tt_all_test04.json
+++ b/tests/tt/results/test_tt_all_test04.json
@@ -4,6 +4,7 @@
     "league": "NCAAF",
     "league_path": "college-football",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": "regular-season",
     "team_abbr": "BGSU",
     "opponent_abbr": "EKU",

--- a/tests/tt/results/test_tt_all_test05.json
+++ b/tests/tt/results/test_tt_all_test05.json
@@ -4,6 +4,7 @@
     "league": "NCAAF",
     "league_path": "college-football",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": "regular-season",
     "team_abbr": "ALA",
     "opponent_abbr": "TEX",

--- a/tests/tt/results/test_tt_all_test06.json
+++ b/tests/tt/results/test_tt_all_test06.json
@@ -4,6 +4,7 @@
     "league": "NFL",
     "league_path": "nfl",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": "regular-season",
     "team_abbr": "BUF",
     "opponent_abbr": "LAR",

--- a/tests/tt/results/test_tt_all_test07.json
+++ b/tests/tt/results/test_tt_all_test07.json
@@ -4,6 +4,7 @@
     "league": "NWSL",
     "league_path": "usa.nwsl",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": "regular-season",
     "team_abbr": "ORL",
     "opponent_abbr": "POR",

--- a/tests/tt/results/test_tt_all_test08.json
+++ b/tests/tt/results/test_tt_all_test08.json
@@ -4,6 +4,7 @@
     "league": "MLS",
     "league_path": "usa.1",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": "regular-season",
     "team_abbr": "CLB",
     "opponent_abbr": "MTL",

--- a/tests/tt/results/test_tt_all_test09.json
+++ b/tests/tt/results/test_tt_all_test09.json
@@ -4,6 +4,7 @@
     "league": "WC",
     "league_path": "fifa.world",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": "final",
     "team_abbr": "ARG",
     "opponent_abbr": "FRA",

--- a/tests/tt/results/test_tt_all_test10.json
+++ b/tests/tt/results/test_tt_all_test10.json
@@ -4,6 +4,7 @@
     "league": "NBA",
     "league_path": "nba",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": "regular-season",
     "team_abbr": "DET",
     "opponent_abbr": "UTAH",

--- a/tests/tt/results/test_tt_all_test11.json
+++ b/tests/tt/results/test_tt_all_test11.json
@@ -4,6 +4,7 @@
     "league": "NBA",
     "league_path": "nba",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": "preseason",
     "team_abbr": "UTAH",
     "opponent_abbr": "TOR",

--- a/tests/tt/results/test_tt_all_test12.json
+++ b/tests/tt/results/test_tt_all_test12.json
@@ -4,6 +4,7 @@
     "league": "NBA",
     "league_path": "nba",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": "preseason",
     "team_abbr": "CHA",
     "opponent_abbr": "BOS",

--- a/tests/tt/results/test_tt_all_test13.json
+++ b/tests/tt/results/test_tt_all_test13.json
@@ -4,6 +4,7 @@
     "league": "NHL",
     "league_path": "nhl",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": "regular-season",
     "team_abbr": "WPG",
     "opponent_abbr": "OTT",

--- a/tests/tt/results/test_tt_all_test14.json
+++ b/tests/tt/results/test_tt_all_test14.json
@@ -4,6 +4,7 @@
     "league": "NHL",
     "league_path": "nhl",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": "preseason",
     "team_abbr": "NYI",
     "opponent_abbr": "PHI",

--- a/tests/tt/results/test_tt_all_test15.json
+++ b/tests/tt/results/test_tt_all_test15.json
@@ -4,6 +4,7 @@
     "league": "NHL",
     "league_path": "nhl",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": "preseason",
     "team_abbr": "CBJ",
     "opponent_abbr": "WSH",

--- a/tests/tt/results/test_tt_all_test16.json
+++ b/tests/tt/results/test_tt_all_test16.json
@@ -4,6 +4,7 @@
     "league": "NCAAVBW",
     "league_path": "womens-college-volleyball",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": "regular-season",
     "team_abbr": "PEPP",
     "opponent_abbr": "CP",

--- a/tests/tt/results/test_tt_all_test17.json
+++ b/tests/tt/results/test_tt_all_test17.json
@@ -4,6 +4,7 @@
     "league": "NCAAVBW",
     "league_path": "womens-college-volleyball",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": "regular-season",
     "team_abbr": "MSST",
     "opponent_abbr": "KENN",

--- a/tests/tt/results/test_tt_all_test18.json
+++ b/tests/tt/results/test_tt_all_test18.json
@@ -4,6 +4,7 @@
     "league": "NCAAVBW",
     "league_path": "womens-college-volleyball",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": "regular-season",
     "team_abbr": "ARMY",
     "opponent_abbr": "SYR",

--- a/tests/tt/results/test_tt_all_test19.json
+++ b/tests/tt/results/test_tt_all_test19.json
@@ -4,6 +4,7 @@
     "league": "ATP",
     "league_path": "atp",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": null,
     "team_abbr": "STRUFF",
     "opponent_abbr": null,

--- a/tests/tt/results/test_tt_all_test20.json
+++ b/tests/tt/results/test_tt_all_test20.json
@@ -4,6 +4,7 @@
     "league": "WTA",
     "league_path": "wta",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": null,
     "team_abbr": null,
     "opponent_abbr": null,

--- a/tests/tt/results/test_tt_all_test21.json
+++ b/tests/tt/results/test_tt_all_test21.json
@@ -4,6 +4,7 @@
     "league": "WTA",
     "league_path": "wta",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": null,
     "team_abbr": "PAOLINI",
     "opponent_abbr": null,

--- a/tests/tt/results/test_tt_all_test22.json
+++ b/tests/tt/results/test_tt_all_test22.json
@@ -4,6 +4,7 @@
     "league": "UFC",
     "league_path": "ufc",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": "regular-season",
     "team_abbr": "STRICKLAND",
     "opponent_abbr": null,

--- a/tests/tt/results/test_tt_all_test23.json
+++ b/tests/tt/results/test_tt_all_test23.json
@@ -4,6 +4,7 @@
     "league": "UFC",
     "league_path": "ufc",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": "regular-season",
     "team_abbr": "CACERES",
     "opponent_abbr": null,

--- a/tests/tt/results/test_tt_all_test24.json
+++ b/tests/tt/results/test_tt_all_test24.json
@@ -4,6 +4,7 @@
     "league": "UFC",
     "league_path": "ufc",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": "regular-season",
     "team_abbr": "FAKHRETDINOV",
     "opponent_abbr": null,

--- a/tests/tt/results/test_tt_all_test25.json
+++ b/tests/tt/results/test_tt_all_test25.json
@@ -4,6 +4,7 @@
     "league": "PGA",
     "league_path": "pga",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": null,
     "team_abbr": "CONNERS",
     "opponent_abbr": null,

--- a/tests/tt/results/test_tt_all_test26.json
+++ b/tests/tt/results/test_tt_all_test26.json
@@ -4,6 +4,7 @@
     "league": "XXX",
     "league_path": "1324623",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": null,
     "team_abbr": "BH",
     "opponent_abbr": "SS",

--- a/tests/tt/results/test_tt_all_test27.json
+++ b/tests/tt/results/test_tt_all_test27.json
@@ -4,6 +4,7 @@
     "league": "XXX",
     "league_path": "1324623",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": null,
     "team_abbr": "MR",
     "opponent_abbr": "PS",

--- a/tests/tt/results/test_tt_all_test28.json
+++ b/tests/tt/results/test_tt_all_test28.json
@@ -4,6 +4,7 @@
     "league": "XXX",
     "league_path": "21108",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": null,
     "team_abbr": "IND",
     "opponent_abbr": "BAN",

--- a/tests/tt/results/test_tt_all_test29.json
+++ b/tests/tt/results/test_tt_all_test29.json
@@ -4,6 +4,7 @@
     "league": "F1",
     "league_path": "f1",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": "regular-season",
     "team_abbr": "SAINTZ",
     "opponent_abbr": null,

--- a/tests/tt/results/test_tt_all_test30.json
+++ b/tests/tt/results/test_tt_all_test30.json
@@ -4,6 +4,7 @@
     "league": "F1",
     "league_path": "f1",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": "regular-season",
     "team_abbr": "VERSTAPPEN",
     "opponent_abbr": null,

--- a/tests/tt/results/test_tt_all_test31.json
+++ b/tests/tt/results/test_tt_all_test31.json
@@ -4,6 +4,7 @@
     "league": "F1",
     "league_path": "f1",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "season": "regular-season",
     "team_abbr": "STROLLZ",
     "opponent_abbr": null,

--- a/tests/tt/results/test_ttm_teste00.json
+++ b/tests/tt/results/test_ttm_teste00.json
@@ -2,6 +2,7 @@
     "sport": "football",
     "league": "NCAAF",
     "league_logo": "https://a.espncdn.com/i/teamlogos/leagues/500/mlb.png",
+    "league_name": "Major League Baseball",
     "team_abbr": "MICH",
     "opponent_abbr": "OSU",
     "event_name": "OSU @ MICH",


### PR DESCRIPTION
## Summary

Refactors the all-league ("all comps") logic per feedback on #291, rebased on v0.15.0:

- **Removed** `async_try_team_schedule` and its parallel pipeline (event merging, `needs_fallback` fast path, separate HTTP calls)
- **Added** `async_get_team_schedule` for lightweight date/competition discovery (cached in `all_team_cache` until next game date passes)
- **Feeds narrow dates** into existing `async_call_api` via `d1_override`/`d2_override` so the standard scoreboard flow, fallbacks, and `data_cache` are reused
- **Uses `league_name`** attribute (new in v0.15.0) plus `league` for backward compat
- **Includes `team_id`** in `data_cache` key for "all" leagues (each team needs different narrow dates)
- **Shows scoreboard call count** and date window in `api_message` for transparency
- **Fixed** `async_unload_entry` calling wrong method name (`async_unload` → `async_shutdown`)

## API call profile

| Scenario | Scoreboard calls | Discovery calls | Total |
|---|---|---|---|
| Next game within 7 days | 1 | 2 (cached) | 3 first time, 0 on refresh |
| Next game beyond 7 days | 2 (recent + next game) | 2 (cached) | 4 first time, 0 on refresh |
| Subsequent refreshes | 0 (data_cache hit) | 0 (all_team_cache hit) | 0 |

## Verified

- All 10 unit tests pass
- Tested live on HA with 9 sensors (NFL, MLB, NHL, NCAAF, soccer all)
- Tottenham (next game >7d away): 2 scoreboard calls, found via fallback to next-game window
- Second soccer "all" sensor (next game <7d): 1 scoreboard call, found directly
- `league` and `league_name` both populated correctly
- Cached refreshes complete in 0.000-0.002s with 0 API calls
- Non-"all" sensors (NFL, MLB, NHL, NCAAF) completely unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)