### PR TITLE
fix: remove last_update from sensor attributes to prevent DB spam

### DIFF
--- a/custom_components/teamtracker/sensor.py
+++ b/custom_components/teamtracker/sensor.py
@@ -390,7 +390,6 @@ class TeamTrackerScoresSensor(CoordinatorEntity):
         attrs["team_sets_won"] = self.coordinator.data["team_sets_won"]
         attrs["opponent_sets_won"] = self.coordinator.data["opponent_sets_won"]
 
-        attrs["last_update"] = self.coordinator.data["last_update"]
         attrs["api_message"] = self.coordinator.data["api_message"]
         attrs["api_url"] = self.coordinator.data["api_url"]
 


### PR DESCRIPTION
## Problem

During live games, the coordinator switches to rapid refresh (every 5 seconds). The `last_update` attribute is a timestamp that changes on **every single poll**, causing HA Recorder to write a new history entry every 5 seconds — leading to uncontrolled database growth over the course of a game.

## Fix

Remove `last_update` from `extra_state_attributes`. The value is still computed internally but no longer exposed as a sensor attribute.

## Note

This fix was previously merged in PR #275 but was not carried over into the v0.16.0-beta rewrite. It is also missing from the current `v0.16.0-Fixes` branch.

## Breaking Change

Any templates or automations using `{{ state_attr('sensor.my_team', 'last_update') }}` will stop working. Use HA's built-in `last_changed` property instead, which reflects when the sensor state actually changed.