### PR TITLE
feat: add opt-in show_last_update option to prevent DB spam by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,11 @@ The following configuration keys can be used when setting up a Team Tracker sens
 | name | Friendly Name| No | Friendly name for the sensor | Any valid friendly name |
 | league_id | League | Yes | League ID | [See below](https://github.com/vasqued2/ha-teamtracker?tab=readme-ov-file#specify-the-league-league_id)|
 | team_id | Team / Athlete | Yes | Team Abbreviation, Team ID, Athlete Name, Regular Expression, or Wildcard | [See below](https://github.com/vasqued2/ha-teamtracker?tab=readme-ov-file#specify-the-team-team_id) |
-| api_language | None | No | Overrides default API language | [ISO language code](https://www.andiamo.co.uk/resources/iso-language-codes/) |
+| api_language | Options Flow | No | Overrides default API language | [ISO language code](https://www.andiamo.co.uk/resources/iso-language-codes/) |
 | conference_id | Conference Number | Only if `league_id` is an NCAA football or basketball | Conference ID  | [See below](https://github.com/vasqued2/ha-teamtracker?tab=readme-ov-file#specify-the-conference---for-ncaa-sports-only-conference_id) |
 | sport_path | Sport Path | If `league_id` is `XXX` | Sport Path for Custom API | [See below](https://github.com/vasqued2/ha-teamtracker?tab=readme-ov-file#custom-apis--how-to-determine-the-sport-path-and-league-path-sport_path-league_path) |
 | league_path | League Path | If `league_id` is `XXX` | League Path for Custom API. The value `all` can be used for soccer teams to pull in all matches across all leagues and tournaments. The unique ESPN Team ID should be used for `team_id` when `all` is used. | [See below](https://github.com/vasqued2/ha-teamtracker?tab=readme-ov-file#custom-apis--how-to-determine-the-sport-path-and-league-path-sport_path-league_path) |
+| record_last_update | Options Flow | No | `last_update` atttribute updated and saved to Recorder when `True` | Boolean |
 
 
 #### Specify the League (league_id)

--- a/custom_components/teamtracker/config_flow.py
+++ b/custom_components/teamtracker/config_flow.py
@@ -11,9 +11,11 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.selector import BooleanSelector
 
 from .const import (
     CONF_API_LANGUAGE,
+    CONF_SHOW_LAST_UPDATE,
     CONF_CONFERENCE_ID,
     CONF_LEAGUE_ID,
     CONF_LEAGUE_PATH,
@@ -529,6 +531,14 @@ class TeamTrackerScoresOptionsFlow(config_entries.OptionsFlow):
         ):
             lang = self.entry.options[CONF_API_LANGUAGE]
 
+        show_last_update = False
+        if (
+            self.entry
+            and self.entry.options
+            and CONF_SHOW_LAST_UPDATE in self.entry.options
+        ):
+            show_last_update = self.entry.options[CONF_SHOW_LAST_UPDATE]
+
         options_schema = vol.Schema(
             {
                 vol.Optional(
@@ -536,6 +546,10 @@ class TeamTrackerScoresOptionsFlow(config_entries.OptionsFlow):
                     description={"suggested_value": lang},
                     default="",
                 ): cv.string,
+                vol.Optional(
+                    CONF_SHOW_LAST_UPDATE,
+                    default=show_last_update,
+                ): BooleanSelector(),
             }
         )
         return self.async_show_form(

--- a/custom_components/teamtracker/config_flow.py
+++ b/custom_components/teamtracker/config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.selector import BooleanSelector
 
 from .const import (
     CONF_API_LANGUAGE,
-    CONF_SHOW_LAST_UPDATE,
+    CONF_RECORD_LAST_UPDATE,
     CONF_CONFERENCE_ID,
     CONF_LEAGUE_ID,
     CONF_LEAGUE_PATH,
@@ -531,13 +531,13 @@ class TeamTrackerScoresOptionsFlow(config_entries.OptionsFlow):
         ):
             lang = self.entry.options[CONF_API_LANGUAGE]
 
-        show_last_update = False
+        record_last_update = False
         if (
             self.entry
             and self.entry.options
-            and CONF_SHOW_LAST_UPDATE in self.entry.options
+            and CONF_RECORD_LAST_UPDATE in self.entry.options
         ):
-            show_last_update = self.entry.options[CONF_SHOW_LAST_UPDATE]
+            record_last_update = self.entry.options[CONF_RECORD_LAST_UPDATE]
 
         options_schema = vol.Schema(
             {
@@ -547,8 +547,8 @@ class TeamTrackerScoresOptionsFlow(config_entries.OptionsFlow):
                     default="",
                 ): cv.string,
                 vol.Optional(
-                    CONF_SHOW_LAST_UPDATE,
-                    default=show_last_update,
+                    CONF_RECORD_LAST_UPDATE,
+                    default=record_last_update,
                 ): BooleanSelector(),
             }
         )

--- a/custom_components/teamtracker/const.py
+++ b/custom_components/teamtracker/const.py
@@ -13,7 +13,7 @@ USER_AGENT = (
 
 # Config
 CONF_API_LANGUAGE = "api_language"
-CONF_SHOW_LAST_UPDATE = "show_last_update"
+CONF_RECORD_LAST_UPDATE = "record_last_update"
 CONF_CONFERENCE_ID = "conference_id"
 CONF_LEAGUE_ID = "league_id"
 CONF_LEAGUE_PATH = "league_path"

--- a/custom_components/teamtracker/const.py
+++ b/custom_components/teamtracker/const.py
@@ -13,6 +13,7 @@ USER_AGENT = (
 
 # Config
 CONF_API_LANGUAGE = "api_language"
+CONF_SHOW_LAST_UPDATE = "show_last_update"
 CONF_CONFERENCE_ID = "conference_id"
 CONF_LEAGUE_ID = "league_id"
 CONF_LEAGUE_PATH = "league_path"

--- a/custom_components/teamtracker/sensor.py
+++ b/custom_components/teamtracker/sensor.py
@@ -51,6 +51,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_API_LANGUAGE): cv.string,
         vol.Optional(CONF_SPORT_PATH): cv.string,
         vol.Optional(CONF_LEAGUE_PATH): cv.string,
+        vol.Optional(CONF_SHOW_LAST_UPDATE, default=False): cv.boolean,
     }
 )
 
@@ -167,7 +168,10 @@ class TeamTrackerScoresSensor(CoordinatorEntity):
             self._show_last_update = entry.options.get(CONF_SHOW_LAST_UPDATE, False) if entry.options else False
             
         else:  # YAML setup, use sensor_name as index (assumes sensor_name = entity_id)
-            self._show_last_update = False
+            try:
+                self._show_last_update = config[CONF_SHOW_LAST_UPDATE]
+            except (KeyError, AttributeError):  # pylint: disable=broad-exception-caught
+                self._show_last_update = False
             sensor_name = config[CONF_NAME]
             entry_id = slugify(f"{config.get(CONF_TEAM_ID)}")
             sensor_coordinator = hass.data[DOMAIN][sensor_name][COORDINATOR]
@@ -395,6 +399,8 @@ class TeamTrackerScoresSensor(CoordinatorEntity):
 
         if self._show_last_update:
             attrs["last_update"] = self.coordinator.data["last_update"]
+        else:
+            attrs["last_update"] = ""
         attrs["api_message"] = self.coordinator.data["api_message"]
         attrs["api_url"] = self.coordinator.data["api_url"]
 

--- a/custom_components/teamtracker/sensor.py
+++ b/custom_components/teamtracker/sensor.py
@@ -390,7 +390,6 @@ class TeamTrackerScoresSensor(CoordinatorEntity):
         attrs["team_sets_won"] = self.coordinator.data["team_sets_won"]
         attrs["opponent_sets_won"] = self.coordinator.data["opponent_sets_won"]
 
-        attrs["last_update"] = self.coordinator.data["last_update"]
         attrs["api_message"] = self.coordinator.data["api_message"]
         attrs["api_url"] = self.coordinator.data["api_url"]
 

--- a/custom_components/teamtracker/sensor.py
+++ b/custom_components/teamtracker/sensor.py
@@ -19,7 +19,7 @@ from . import TeamTrackerDataUpdateCoordinator
 from .const import (
     ATTRIBUTION,
     CONF_API_LANGUAGE,
-    CONF_SHOW_LAST_UPDATE,
+    CONF_RECORD_LAST_UPDATE,
     CONF_CONFERENCE_ID,
     CONF_LEAGUE_ID,
     CONF_LEAGUE_PATH,
@@ -51,7 +51,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_API_LANGUAGE): cv.string,
         vol.Optional(CONF_SPORT_PATH): cv.string,
         vol.Optional(CONF_LEAGUE_PATH): cv.string,
-        vol.Optional(CONF_SHOW_LAST_UPDATE, default=False): cv.boolean,
+        vol.Optional(CONF_RECORD_LAST_UPDATE, default=False): cv.boolean,
     }
 )
 
@@ -165,13 +165,13 @@ class TeamTrackerScoresSensor(CoordinatorEntity):
             super().__init__(sensor_coordinator)
             sport_path = entry.data.get(CONF_SPORT_PATH, DEFAULT_SPORT_PATH)
             sensor_name = entry.data[CONF_NAME]
-            self._show_last_update = entry.options.get(CONF_SHOW_LAST_UPDATE, False) if entry.options else False
+            self._record_last_update = entry.options.get(CONF_RECORD_LAST_UPDATE, False) if entry.options else False
             
         else:  # YAML setup, use sensor_name as index (assumes sensor_name = entity_id)
             try:
-                self._show_last_update = config[CONF_SHOW_LAST_UPDATE]
+                self._record_last_update = config[CONF_RECORD_LAST_UPDATE]
             except (KeyError, AttributeError):  # pylint: disable=broad-exception-caught
-                self._show_last_update = False
+                self._record_last_update = False
             sensor_name = config[CONF_NAME]
             entry_id = slugify(f"{config.get(CONF_TEAM_ID)}")
             sensor_coordinator = hass.data[DOMAIN][sensor_name][COORDINATOR]
@@ -397,7 +397,7 @@ class TeamTrackerScoresSensor(CoordinatorEntity):
         attrs["team_sets_won"] = self.coordinator.data["team_sets_won"]
         attrs["opponent_sets_won"] = self.coordinator.data["opponent_sets_won"]
 
-        if self._show_last_update:
+        if self._record_last_update:
             attrs["last_update"] = self.coordinator.data["last_update"]
         else:
             attrs["last_update"] = ""

--- a/custom_components/teamtracker/sensor.py
+++ b/custom_components/teamtracker/sensor.py
@@ -19,6 +19,7 @@ from . import TeamTrackerDataUpdateCoordinator
 from .const import (
     ATTRIBUTION,
     CONF_API_LANGUAGE,
+    CONF_SHOW_LAST_UPDATE,
     CONF_CONFERENCE_ID,
     CONF_LEAGUE_ID,
     CONF_LEAGUE_PATH,
@@ -163,8 +164,10 @@ class TeamTrackerScoresSensor(CoordinatorEntity):
             super().__init__(sensor_coordinator)
             sport_path = entry.data.get(CONF_SPORT_PATH, DEFAULT_SPORT_PATH)
             sensor_name = entry.data[CONF_NAME]
+            self._show_last_update = entry.options.get(CONF_SHOW_LAST_UPDATE, False) if entry.options else False
             
         else:  # YAML setup, use sensor_name as index (assumes sensor_name = entity_id)
+            self._show_last_update = False
             sensor_name = config[CONF_NAME]
             entry_id = slugify(f"{config.get(CONF_TEAM_ID)}")
             sensor_coordinator = hass.data[DOMAIN][sensor_name][COORDINATOR]
@@ -390,6 +393,8 @@ class TeamTrackerScoresSensor(CoordinatorEntity):
         attrs["team_sets_won"] = self.coordinator.data["team_sets_won"]
         attrs["opponent_sets_won"] = self.coordinator.data["opponent_sets_won"]
 
+        if self._show_last_update:
+            attrs["last_update"] = self.coordinator.data["last_update"]
         attrs["api_message"] = self.coordinator.data["api_message"]
         attrs["api_url"] = self.coordinator.data["api_url"]
 

--- a/custom_components/teamtracker/strings.json
+++ b/custom_components/teamtracker/strings.json
@@ -70,7 +70,7 @@
         "description": "Enter the 2-character language code to use for the API call.",
         "data": {
           "api_language": "API Language",
-          "show_last_update": "Show last_update attribute (may cause DB spam during live games)"
+          "record_last_update": "Save last_update attribute in Recorder"
         }
       }
     }

--- a/custom_components/teamtracker/strings.json
+++ b/custom_components/teamtracker/strings.json
@@ -69,7 +69,8 @@
         "title": "Team Tracker Options",
         "description": "Enter the 2-character language code to use for the API call.",
         "data": {
-          "api_language": "API Language"
+          "api_language": "API Language",
+          "show_last_update": "Show last_update attribute (may cause DB spam during live games)"
         }
       }
     }

--- a/custom_components/teamtracker/translations/de.json
+++ b/custom_components/teamtracker/translations/de.json
@@ -1,21 +1,21 @@
 {
   "config": {
     "error": {
-      "league": "Ungültige Liga eingegeben.",
-      "cannot_fetch_teams": "Teams konnten nicht von ESPN abgerufen werden. Überprüfen Sie Ihre Verbindung und versuchen Sie es erneut.",
-      "no_teams_found": "Keine Teams für diesen Suchbegriff gefunden. Versuchen Sie einen anderen Namen oder lassen Sie das Feld für eine manuelle Eingabe leer."
+      "league": "UngÃ¼ltige Liga eingegeben.",
+      "cannot_fetch_teams": "Teams konnten nicht von ESPN abgerufen werden. ÃberprÃ¼fen Sie Ihre Verbindung und versuchen Sie es erneut.",
+      "no_teams_found": "Keine Teams fÃ¼r diesen Suchbegriff gefunden. Versuchen Sie einen anderen Namen oder lassen Sie das Feld fÃ¼r eine manuelle Eingabe leer."
     },
     "step": {
       "user": {
-        "title": "Sportart auswählen",
-        "description": "Wählen Sie die Sportart für Ihr Team oder Ihren Athleten.",
+        "title": "Sportart auswÃ¤hlen",
+        "description": "WÃ¤hlen Sie die Sportart fÃ¼r Ihr Team oder Ihren Athleten.",
         "data": {
           "sport_key": "Sportart"
         }
       },
       "league": {
-        "title": "Liga auswählen",
-        "description": "Wählen Sie die {sport_name}-Liga.",
+        "title": "Liga auswÃ¤hlen",
+        "description": "WÃ¤hlen Sie die {sport_name}-Liga.",
         "data": {
           "league_id": "Liga"
         }
@@ -28,8 +28,8 @@
         }
       },
       "select_team": {
-        "title": "Team auswählen",
-        "description": "Wählen Sie Ihr {league_name}-Team aus den Suchergebnissen aus.",
+        "title": "Team auswÃ¤hlen",
+        "description": "WÃ¤hlen Sie Ihr {league_name}-Team aus den Suchergebnissen aus.",
         "data": {
           "team_selection": "Team",
           "name": "Anzeigename (optional)"
@@ -37,7 +37,7 @@
       },
       "manual_team": {
         "title": "Manuelle Teameingabe",
-        "description": "Geben Sie die {league_name}-Teamabkürzung oder die ID-Nummer wie auf ESPN angezeigt ein, oder '*' für das aktive/aktuellste Spiel.",
+        "description": "Geben Sie die {league_name}-TeamabkÃ¼rzung oder die ID-Nummer wie auf ESPN angezeigt ein, oder '*' fÃ¼r das aktive/aktuellste Spiel.",
         "data": {
           "team_id": "Team-ID",
           "conference_id": "Konferenz-Nummer",
@@ -46,7 +46,7 @@
       },
       "manual_athlete": {
         "title": "Manuelle Athleteneingabe",
-        "description": "Geben Sie den Namen des {league_name}-Athleten, einen regulären Ausdruck oder '*' für das aktive/aktuellste Spiel ein.",
+        "description": "Geben Sie den Namen des {league_name}-Athleten, einen regulÃ¤ren Ausdruck oder '*' fÃ¼r das aktive/aktuellste Spiel ein.",
         "data": {
           "team_id": "Athleten-ID",
           "conference_id": "Konferenz-Nummer (nur NCAA)",
@@ -67,9 +67,10 @@
     "step": {
       "init": {
         "title": "Team Tracker Optionen",
-        "description": "Geben Sie den 2-stelligen Sprachcode für den API-Aufruf ein.",
+        "description": "Geben Sie den 2-stelligen Sprachcode fÃ¼r den API-Aufruf ein.",
         "data": {
-          "api_language": "API-Sprache"
+          "api_language": "API-Sprache",
+          "show_last_update": "last_update-Attribut anzeigen (kann waehrend Live-Spielen zu DB-Spam fuehren)"
         }
       }
     }

--- a/custom_components/teamtracker/translations/de.json
+++ b/custom_components/teamtracker/translations/de.json
@@ -70,7 +70,7 @@
         "description": "Geben Sie den 2-stelligen Sprachcode fÃ¼r den API-Aufruf ein.",
         "data": {
           "api_language": "API-Sprache",
-          "show_last_update": "last_update-Attribut anzeigen (kann waehrend Live-Spielen zu DB-Spam fuehren)"
+          "record_last_update": "Attribut last_update im Recorder speichern"
         }
       }
     }

--- a/custom_components/teamtracker/translations/el.json
+++ b/custom_components/teamtracker/translations/el.json
@@ -70,7 +70,7 @@
         "description": "Εισαγάγετε τον διψήφιο κωδικό γλώσσας για χρήση στην κλήση API.",
         "data": {
           "api_language": "Γλώσσα API",
-          "show_last_update": "Show last_update attribute (may cause DB spam during live games)"
+          "record_last_update": "Αποθήκευση του χαρακτηριστικού last_update στο Recorder"
         }
       }
     }

--- a/custom_components/teamtracker/translations/el.json
+++ b/custom_components/teamtracker/translations/el.json
@@ -69,7 +69,8 @@
         "title": "Επιλογές Team Tracker",
         "description": "Εισαγάγετε τον διψήφιο κωδικό γλώσσας για χρήση στην κλήση API.",
         "data": {
-          "api_language": "Γλώσσα API"
+          "api_language": "Γλώσσα API",
+          "show_last_update": "Show last_update attribute (may cause DB spam during live games)"
         }
       }
     }

--- a/custom_components/teamtracker/translations/en.json
+++ b/custom_components/teamtracker/translations/en.json
@@ -70,7 +70,7 @@
         "description": "Enter the 2-character language code to use for the API call.",
         "data": {
           "api_language": "API Language",
-          "show_last_update": "Show last_update attribute (may cause DB spam during live games)"
+          "record_last_update": "Save last_update attribute in Recorder"
         }
       }
     }

--- a/custom_components/teamtracker/translations/en.json
+++ b/custom_components/teamtracker/translations/en.json
@@ -69,7 +69,8 @@
         "title": "Team Tracker Options",
         "description": "Enter the 2-character language code to use for the API call.",
         "data": {
-          "api_language": "API Language"
+          "api_language": "API Language",
+          "show_last_update": "Show last_update attribute (may cause DB spam during live games)"
         }
       }
     }

--- a/custom_components/teamtracker/translations/es.json
+++ b/custom_components/teamtracker/translations/es.json
@@ -69,7 +69,8 @@
         "title": "Opciones de Team Tracker",
         "description": "Ingrese el código de idioma de 2 caracteres para usar en la llamada a la API.",
         "data": {
-          "api_language": "Idioma de la API"
+          "api_language": "Idioma de la API",
+          "show_last_update": "Mostrar atributo last_update (puede causar spam en la BD durante partidos en vivo)"
         }
       }
     }

--- a/custom_components/teamtracker/translations/es.json
+++ b/custom_components/teamtracker/translations/es.json
@@ -70,7 +70,7 @@
         "description": "Ingrese el código de idioma de 2 caracteres para usar en la llamada a la API.",
         "data": {
           "api_language": "Idioma de la API",
-          "show_last_update": "Mostrar atributo last_update (puede causar spam en la BD durante partidos en vivo)"
+          "record_last_update": "Guardar el atributo last_update en el Recorder"
         }
       }
     }

--- a/custom_components/teamtracker/translations/es_419.json
+++ b/custom_components/teamtracker/translations/es_419.json
@@ -69,7 +69,8 @@
         "title": "Opciones de Team Tracker",
         "description": "Ingrese el código de idioma de 2 caracteres para usar en la llamada a la API.",
         "data": {
-          "api_language": "Idioma de la API"
+          "api_language": "Idioma de la API",
+          "show_last_update": "Mostrar atributo last_update (puede causar spam en la BD durante partidos en vivo)"
         }
       }
     }

--- a/custom_components/teamtracker/translations/es_419.json
+++ b/custom_components/teamtracker/translations/es_419.json
@@ -70,7 +70,7 @@
         "description": "Ingrese el código de idioma de 2 caracteres para usar en la llamada a la API.",
         "data": {
           "api_language": "Idioma de la API",
-          "show_last_update": "Mostrar atributo last_update (puede causar spam en la BD durante partidos en vivo)"
+          "record_last_update": "Guardar el atributo last_update en el Recorder"
         }
       }
     }

--- a/custom_components/teamtracker/translations/fr.json
+++ b/custom_components/teamtracker/translations/fr.json
@@ -70,7 +70,7 @@
         "description": "Saisissez le code de langue à 2 caractères à utiliser pour l'appel API.",
         "data": {
           "api_language": "Langue de l'API",
-          "show_last_update": "Afficher l'attribut last_update (peut causer du spam en BD pendant les matchs en direct)"
+          "record_last_update": "Sauvegarder l'attribut last_update dans le Recorder"
         }
       }
     }

--- a/custom_components/teamtracker/translations/fr.json
+++ b/custom_components/teamtracker/translations/fr.json
@@ -69,7 +69,8 @@
         "title": "Options de Team Tracker",
         "description": "Saisissez le code de langue à 2 caractères à utiliser pour l'appel API.",
         "data": {
-          "api_language": "Langue de l'API"
+          "api_language": "Langue de l'API",
+          "show_last_update": "Afficher l'attribut last_update (peut causer du spam en BD pendant les matchs en direct)"
         }
       }
     }

--- a/custom_components/teamtracker/translations/it.json
+++ b/custom_components/teamtracker/translations/it.json
@@ -70,7 +70,7 @@
         "description": "Inserisci il codice lingua a 2 caratteri da utilizzare per la chiamata API.",
         "data": {
           "api_language": "Lingua API",
-          "show_last_update": "Show last_update attribute (may cause DB spam during live games)"
+          "record_last_update": "Salva l'attributo last_update nel Recorder"
         }
       }
     }

--- a/custom_components/teamtracker/translations/it.json
+++ b/custom_components/teamtracker/translations/it.json
@@ -69,7 +69,8 @@
         "title": "Opzioni Team Tracker",
         "description": "Inserisci il codice lingua a 2 caratteri da utilizzare per la chiamata API.",
         "data": {
-          "api_language": "Lingua API"
+          "api_language": "Lingua API",
+          "show_last_update": "Show last_update attribute (may cause DB spam during live games)"
         }
       }
     }

--- a/custom_components/teamtracker/translations/nl.json
+++ b/custom_components/teamtracker/translations/nl.json
@@ -70,7 +70,7 @@
         "description": "Voer de taalcode van 2 tekens in die moet worden gebruikt voor de API-aanroep.",
         "data": {
           "api_language": "API Taal",
-          "show_last_update": "Show last_update attribute (may cause DB spam during live games)"
+          "record_last_update": "Kenmerk last_update opslaan in de Recorder"
         }
       }
     }

--- a/custom_components/teamtracker/translations/nl.json
+++ b/custom_components/teamtracker/translations/nl.json
@@ -69,7 +69,8 @@
         "title": "Team Tracker Opties",
         "description": "Voer de taalcode van 2 tekens in die moet worden gebruikt voor de API-aanroep.",
         "data": {
-          "api_language": "API Taal"
+          "api_language": "API Taal",
+          "show_last_update": "Show last_update attribute (may cause DB spam during live games)"
         }
       }
     }

--- a/custom_components/teamtracker/translations/pt-BR.json
+++ b/custom_components/teamtracker/translations/pt-BR.json
@@ -70,7 +70,7 @@
         "description": "Insira o código de idioma de 2 caracteres para usar na chamada da API.",
         "data": {
           "api_language": "Idioma da API",
-          "show_last_update": "Mostrar atributo last_update (pode causar spam no BD durante jogos ao vivo)"
+          "record_last_update": "Salvar o atributo last_update no Recorder"
         }
       }
     }

--- a/custom_components/teamtracker/translations/pt-BR.json
+++ b/custom_components/teamtracker/translations/pt-BR.json
@@ -69,7 +69,8 @@
         "title": "Opções do Team Tracker",
         "description": "Insira o código de idioma de 2 caracteres para usar na chamada da API.",
         "data": {
-          "api_language": "Idioma da API"
+          "api_language": "Idioma da API",
+          "show_last_update": "Mostrar atributo last_update (pode causar spam no BD durante jogos ao vivo)"
         }
       }
     }

--- a/custom_components/teamtracker/translations/sk.json
+++ b/custom_components/teamtracker/translations/sk.json
@@ -69,7 +69,8 @@
         "title": "Možnosti Team Tracker",
         "description": "Zadajte 2-miestny kód jazyka, ktorý sa má použiť pre volanie API.",
         "data": {
-          "api_language": "Jazyk API"
+          "api_language": "Jazyk API",
+          "show_last_update": "Zobrazit atribut last_update (moze sposobit spam v DB pocas zivych zapasov)"
         }
       }
     }

--- a/custom_components/teamtracker/translations/sk.json
+++ b/custom_components/teamtracker/translations/sk.json
@@ -70,7 +70,7 @@
         "description": "Zadajte 2-miestny kód jazyka, ktorý sa má použiť pre volanie API.",
         "data": {
           "api_language": "Jazyk API",
-          "show_last_update": "Zobrazit atribut last_update (moze sposobit spam v DB pocas zivych zapasov)"
+          "record_last_update": "Uložiť atribút last_update do Recordera"
         }
       }
     }

--- a/custom_components/teamtracker/translations/sk_SK.json
+++ b/custom_components/teamtracker/translations/sk_SK.json
@@ -69,7 +69,8 @@
         "title": "Možnosti Team Tracker",
         "description": "Zadajte 2-miestny kód jazyka, ktorý sa má použiť pre volanie API.",
         "data": {
-          "api_language": "Jazyk API"
+          "api_language": "Jazyk API",
+          "show_last_update": "Zobrazit atribut last_update (moze sposobit spam v DB pocas zivych zapasov)"
         }
       }
     }

--- a/custom_components/teamtracker/translations/sk_SK.json
+++ b/custom_components/teamtracker/translations/sk_SK.json
@@ -70,7 +70,7 @@
         "description": "Zadajte 2-miestny kód jazyka, ktorý sa má použiť pre volanie API.",
         "data": {
           "api_language": "Jazyk API",
-          "show_last_update": "Zobrazit atribut last_update (moze sposobit spam v DB pocas zivych zapasov)"
+          "record_last_update": "Uložiť atribút last_update do Recordera"
         }
       }
     }

--- a/custom_components/teamtracker/translations/sv.json
+++ b/custom_components/teamtracker/translations/sv.json
@@ -70,7 +70,7 @@
         "description": "Ange den 2-ställiga språkkoden som ska användas för API-anropet.",
         "data": {
           "api_language": "API Språk",
-          "show_last_update": "Show last_update attribute (may cause DB spam during live games)"
+          "record_last_update": "Spara attributet last_update i Recorder"
         }
       }
     }

--- a/custom_components/teamtracker/translations/sv.json
+++ b/custom_components/teamtracker/translations/sv.json
@@ -69,7 +69,8 @@
         "title": "Team Tracker Alternativ",
         "description": "Ange den 2-ställiga språkkoden som ska användas för API-anropet.",
         "data": {
-          "api_language": "API Språk"
+          "api_language": "API Språk",
+          "show_last_update": "Show last_update attribute (may cause DB spam during live games)"
         }
       }
     }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,7 +2,7 @@
 from unittest.mock import patch
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.teamtracker.const import DOMAIN, CONF_API_LANGUAGE, CONF_SHOW_LAST_UPDATE
+from custom_components.teamtracker.const import DOMAIN, CONF_API_LANGUAGE, CONF_RECORD_LAST_UPDATE
 from homeassistant import setup
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from tests.const import CONFIG_DATA
@@ -322,11 +322,11 @@ async def test_options_flow_init(hass):
 
     # Submit Form with Options
     result = await hass.config_entries.options.async_configure(
-        result["flow_id"], user_input={"api_language": "en", "show_last_update": False}
+        result["flow_id"], user_input={"api_language": "en", "record_last_update": False}
     )
 
     assert "create_entry" == result["type"]
     assert "" == result["title"]
-    assert {CONF_API_LANGUAGE: "en", CONF_SHOW_LAST_UPDATE: False} == result["data"]
+    assert {CONF_API_LANGUAGE: "en", CONF_RECORD_LAST_UPDATE: False} == result["data"]
 
     await hass.async_block_till_done()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,7 +2,7 @@
 from unittest.mock import patch
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.teamtracker.const import DOMAIN, CONF_API_LANGUAGE
+from custom_components.teamtracker.const import DOMAIN, CONF_API_LANGUAGE, CONF_SHOW_LAST_UPDATE
 from homeassistant import setup
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from tests.const import CONFIG_DATA
@@ -322,11 +322,11 @@ async def test_options_flow_init(hass):
 
     # Submit Form with Options
     result = await hass.config_entries.options.async_configure(
-        result["flow_id"], user_input={"api_language": "en"}
+        result["flow_id"], user_input={"api_language": "en", "show_last_update": False}
     )
 
     assert "create_entry" == result["type"]
     assert "" == result["title"]
-    assert {CONF_API_LANGUAGE: "en"} == result["data"]
+    assert {CONF_API_LANGUAGE: "en", CONF_SHOW_LAST_UPDATE: False} == result["data"]
 
     await hass.async_block_till_done()


### PR DESCRIPTION
## Context

This is the alternative approach to PR #303 (remove `last_update` entirely), as discussed in the comments there.

## Problem

During live games with rapid refresh (every 5 seconds), the `last_update` timestamp changes on every poll — causing HA Recorder to write a new history entry every 5 seconds and leading to uncontrolled database growth.

## Solution

- `last_update` is **hidden by default** (no DB spam)
- Users can opt-in per sensor via the integration's Options Flow (same place as `api_language`)
- Useful for debugging without impacting everyone

## Changes

- `const.py`: Add `CONF_SHOW_LAST_UPDATE = "show_last_update"`
- `config_flow.py`: Add boolean toggle to Options Flow using `BooleanSelector`
- `sensor.py`: Only expose `last_update` attribute when option is enabled
- `strings.json` + all 12 translation files: Add label for the new toggle

## Note

This also includes the base fix from PR #303 (remove `last_update` unconditionally). If you prefer this approach over #303, #303 can be closed.