### PR TITLE
Fix league_name empty for all-league soccer sensors after game ends (e.g. EPL)

### DIFF
--- a/custom_components/teamtracker/__init__.py
+++ b/custom_components/teamtracker/__init__.py
@@ -57,6 +57,19 @@ _LOGGER = logging.getLogger(__name__)
 # oppo_prob = {}
 
 
+def _slug_to_name(slug: str) -> str:
+    """Convert a season slug like '2025-26-english-premier-league' to 'English Premier League'."""
+    if not slug:
+        return ""
+    body = re.sub(r"^\d{4}(-\d{2})?-", "", slug)
+    if body == slug:
+        return ""
+    def _fmt_word(w):
+        # Uppercase abbreviations (no vowels, e.g. "mls", "nfl"); title-case real words
+        return w.upper() if w.isalpha() and not re.search(r"[aeiou]", w, re.I) else w.title()
+    return " ".join(_fmt_word(w) for w in body.split("-"))
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Load the saved entities."""
 
@@ -469,17 +482,27 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
         if team_data:
             next_events = team_data.get("team", {}).get("nextEvent", [])
             for ne in next_events:
-                display = ne.get("season", {}).get("displayName")
-                if ne.get("id") and display:
-                    id_to_competition[ne["id"]] = display
+                eid = ne.get("id")
+                if not eid:
+                    continue
+                display = ne.get("season", {}).get("displayName") or _slug_to_name(
+                    ne.get("season", {}).get("slug", "")
+                )
+                if display:
+                    id_to_competition[str(eid)] = display
 
         schedule_url = team_url + "/schedule"
         sched_data = await self.async_call_espn_api(schedule_url)
         if sched_data:
             for e in sched_data.get("events", []):
-                display = e.get("season", {}).get("displayName")
-                if e.get("id") and display:
-                    id_to_competition[e["id"]] = display
+                eid = e.get("id")
+                if not eid:
+                    continue
+                display = e.get("season", {}).get("displayName") or _slug_to_name(
+                    e.get("season", {}).get("slug", "")
+                )
+                if display:
+                    id_to_competition[str(eid)] = display
 
 
         next_game_date = (
@@ -509,6 +532,13 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
             competition = id_to_competition.get(game_id)
             if competition:
                 name = re.sub(r"^\d{4}(-\d{2})?\s+", "", competition)
+                values["league_name"] = name
+                values["league"] = name
+
+        # Fallback: derive from season slug already present in scoreboard data
+        if not values.get("league_name"):
+            name = _slug_to_name(values.get("season") or "")
+            if name:
                 values["league_name"] = name
                 values["league"] = name
 

--- a/custom_components/teamtracker/const.py
+++ b/custom_components/teamtracker/const.py
@@ -197,7 +197,7 @@ INDIVIDUAL_SPORTS = {"golf", "mma", "tennis"}
 
 # Misc
 TEAM_ID = ""
-VERSION = "v0.16.1"
+VERSION = "v0.16.2"
 ISSUE_URL = "https://github.com/vasqued2/ha-teamtracker"
 DOMAIN = "teamtracker"
 ATTRIBUTION = "Data provided by ESPN"

--- a/custom_components/teamtracker/manifest.json
+++ b/custom_components/teamtracker/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/vasqued2/ha-teamtracker/issues",
   "requirements": ["arrow", "aiofiles"],
-  "version": "0.16.1"
+  "version": "0.16.2"
 }


### PR DESCRIPTION
## Summary

`league_name` is blank for `league_path: all` soccer sensors (e.g. Tottenham/EPL) once a game moves to POST state.

**Root cause:** Before/during the game the `all_team_cache` is built while the game is still in `nextEvent`, which includes `season.displayName` — so PRE/IN works. After the game the cache expires and is rebuilt; `nextEvent` now points to the next future game, and the team schedule endpoint only returns `season.slug` (not `season.displayName`) for European leagues. So `id_to_competition` ends up empty for the completed game and `league_name` stays blank.

**Fix:**
- Add `_slug_to_name()` helper that converts slugs like `2025-26-english-premier-league` → `English Premier League`, uppercasing vowel-free abbreviations (MLS, NFL) and title-casing real words
- Fall back to `season.slug` when `season.displayName` is absent while building `id_to_competition` in `async_get_team_schedule`; always store keys as strings to match the regex-based lookup
- Add a second fallback in `_enrich_league_name` using the `season.slug` already on the matched scoreboard event, so league name is populated even if the schedule API missed the game

## Test plan

- [ ] Confirm `league_name` populates (e.g. "English Premier League") for a Tottenham / `league_path: all` sensor that previously showed `""` after the game ended
- [ ] Confirm MLS all-league sensors still show "MLS" (not "Mls")
- [ ] `pytest tests/` — all 20 tests pass