### PR TITLE
Add Ability to Search & Select Teams from HockeyTech APIs (Intended for Pre-Release Only)

### DIFF
--- a/custom_components/teamtracker/__init__.py
+++ b/custom_components/teamtracker/__init__.py
@@ -500,14 +500,13 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
         league_path = self.league_path
         if self.data_provider == DATA_PROVIDER_HOCKEYTECH:
             response = await async_fetch_hockeytech_data(hass, league_path.upper(), self.name, lang)
-            data = response["data"]
-            self.api_url = response["url"]
         elif (league_path == "all") and is_integer(self.team_id):
-            data = await self.async_fetch_espn_all_leagues_data(hass, lang)
+            response = await self.async_fetch_espn_all_leagues_data(hass, lang)
         else:
-            data = await self.async_fetch_espn_data(hass, lang)
+            response = await self.async_fetch_espn_data(hass, lang)
 
-        return data
+        self.api_url = response["url"]
+        return response["data"]
 
 
     #
@@ -617,8 +616,7 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
             data = response["data"]
             url = response["url"]
                     
-        self.api_url = url
-        return data
+        return {"data": data, "url": url}
 
 
     #
@@ -685,9 +683,7 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
                     data = response["data"]
                     url = response["url"]
 
-                
-        self.api_url = url
-        return data
+        return {"data": data, "url": url}
 
 
     #

--- a/custom_components/teamtracker/__init__.py
+++ b/custom_components/teamtracker/__init__.py
@@ -393,6 +393,8 @@ class TeamTrackerDataUpdateCoordinator(DataUpdateCoordinator):
     #          async_call_espn_api() - Mockable, overridable API call for ESPN APIs
     #        async_fetch_espn_all_leagues_data() - Gets data from ESPN APIs for all leagues in specified sport
     #          async_call_espn_api() - Mockable, overridable API call for ESPN APIs
+    #        async_fetch_hockeytech_data() - Gets data from HockeyTech APIs for specified league
+    #          async_call_hockeytech_api() - Mockable, overridable API call for HockeyTech APIs
     #      async_update_values() - Updates sensor values using data returned by API or in cache
     #        async_process_event() - Parses ESPN event structure and populates values for sensor
     #

--- a/custom_components/teamtracker/config_flow.py
+++ b/custom_components/teamtracker/config_flow.py
@@ -23,6 +23,11 @@ from .const import (
     INDIVIDUAL_SPORTS,
     LEAGUE_MAP,
 )
+from .hockeytech import (
+    async_fetch_hockeytech_team_data,
+    DATA_PROVIDER_HOCKEYTECH,
+)
+
 from .utils import async_call_espn_api
 
 _LOGGER = logging.getLogger(__name__)
@@ -91,9 +96,39 @@ SPORT_OPTIONS: dict[str, str] = {
     **{k: v[0] for k, v in _SPORT_GROUPS.items()}
 }
 
+#
+# Return a list of team dictionaries
+#  [{
+#   "id": team_id,
+#   "displayName": Long Team Name
+#   "location": City, State, Country of team
+#    "conference_id": Conference for the team (NCAA Only)
+#  }]
+#
+async def async_call_teams_apis(hass: HomeAssistant, league_id: str, sport_path: str, league_path: str) -> list[dict]:
+    """Fetch teams from any API for a given league."""
 
-async def _fetch_teams(hass: HomeAssistant, league_id: str, sport_path: str, league_path: str) -> list[dict]:
-    """Fetch teams from ESPN API for a given league."""
+    if sport_path.lower() == DATA_PROVIDER_HOCKEYTECH.lower():
+        response = await async_fetch_hockeytech_team_data(hass, league_path.upper())
+    elif (league_path == "all"):
+        response = {"data": None}
+    else:
+        response = await async_fetch_espn_team_data(hass, league_id, sport_path, league_path)
+
+    return response["data"]
+
+#
+# Return a list of team dictionaries
+#  [{
+#   "id": team_id,
+#   "displayName": Long Team Name
+#   "location": City, State, Country of team
+#    "conference_id": Conference for the team (NCAA Only)
+#  }]
+#
+
+async def async_fetch_espn_team_data(hass: HomeAssistant, league_id: str, sport_path: str, league_path: str) -> list[dict]:
+    """Fetch teams from any API for a given league."""
     if league_id not in LEAGUE_MAP:
         sport = sport_path
         league = league_path
@@ -108,6 +143,7 @@ async def _fetch_teams(hass: HomeAssistant, league_id: str, sport_path: str, lea
     url_parms = {"limit": 1000}
     response = await async_call_espn_api(hass, url, url_parms, "ConfigFlow-teams", league)
     data = response["data"]
+    url = response["url"]
     if data:
         raw = (
             data.get("sports", [{}])[0]
@@ -116,7 +152,8 @@ async def _fetch_teams(hass: HomeAssistant, league_id: str, sport_path: str, lea
         )
     else:
         raw = []
-        
+
+    # Build the teams data
     teams = []
     for entry in raw:
         t = entry.get("team", {})
@@ -127,7 +164,7 @@ async def _fetch_teams(hass: HomeAssistant, league_id: str, sport_path: str, lea
             "location":      t.get("location", ""),
             "conference_id": (t.get("groups") or {}).get("id", ""),
         })
-    return teams
+    return {"data": teams, "url": url}
 
 
 async def _fetch_team_conference_id(
@@ -295,7 +332,7 @@ class TeamTrackerScoresFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             search_term = user_input.get("search_team", "").strip().lower()
 
             if search_term:
-                self._all_teams = await _fetch_teams(self.hass, self._league_id, self._sport_path, self._league_path)
+                self._all_teams = await async_call_teams_apis(self.hass, self._league_id, self._sport_path, self._league_path)
                 if not self._all_teams:
                     self._errors["base"] = "cannot_fetch_teams"
                 else:

--- a/custom_components/teamtracker/hockeytech.py
+++ b/custom_components/teamtracker/hockeytech.py
@@ -4,10 +4,12 @@ import json
 import logging
 from datetime import datetime, timezone, timedelta
 from yarl import URL
+import locale
 
 import aiohttp
 
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.core import HomeAssistant
 
 from .const import (
     USER_AGENT,
@@ -19,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 # HockeyTech API Definitions
 #
 # Public keys and API documentation provided by:
-#    https://www.mintlify.com/Pharaoh-Labs/teamarr/reference/provider-hockeytech
+#    https://mintlify.wiki/Pharaoh-Labs/teamarr/reference/provider-hockeytech
 #    https://github.com/IsabelleLefebvre97/PWHL-Data-Reference
 #
 DATA_PROVIDER_HOCKEYTECH = "hockeytech"
@@ -135,6 +137,101 @@ _STATUS_MAP = {
     "4": "post",
 }
 
+#
+# Return a list of team dictionaries
+#  [{
+#   "id": team_id,
+#   "displayName": Long Team Name
+#   "location": City, State, Country of team
+#    "conference_id": Conference for the team (NCAA Only)
+#  }]
+#
+
+async def async_fetch_hockeytech_team_data(hass: HomeAssistant, league_id: str) -> list[dict]:
+    """Fetch teams from any API for a given league."""
+
+    sensor_name = "hockeytech_teamsbyseason"
+    league_config = HOCKEYTECH_LEAGUES.get(league_id)
+    if league_config is None:
+        _LOGGER.warning(
+            "%s: No HockeyTech config for league '%s'", sensor_name, league_id
+        )
+        return {"data": None, "url": None}
+
+    try:
+        lang = hass.config.language
+    except:
+        lang, _ = locale.getlocale()
+        lang = lang or "en"
+
+#
+#   Get the most recent regular season
+#      career = 1, playoffs = 0
+#
+    params = {
+        "feed": "modulekit",
+        "view": "seasons",
+        "key": league_config["public_key"],
+        "client_code": league_config["client_code"],
+    }
+
+    ht_response = await async_call_hockeytech_api(hass, HOCKEYTECH_BASE_URL, params, sensor_name, league_id)
+    ht_data = ht_response["ht_data"]
+    url = ht_response["url"]
+
+    if ht_data:
+        seasons = (
+            ht_data.get("SiteKit", [{}])
+            .get("Seasons", [])
+        )
+    else:
+        seasons = []
+
+    season = {}
+    for s in seasons:
+        if s["career"] == "1" and s["playoff"] == "0":
+            season = s
+            break
+
+    season_id = season.get("season_id", 0)
+
+#
+#   Get the list of teams for the most recent regular season
+#
+    params = {
+        "feed": "modulekit",
+        "view": "teamsbyseason",
+        "season_id": season_id,                                         # Hardcode 25/26 PWHL Season
+        "key": league_config["public_key"],
+        "client_code": league_config["client_code"],
+        "lang": lang,
+        "fmt": "json",
+    }
+
+    ht_response = await async_call_hockeytech_api(hass, HOCKEYTECH_BASE_URL, params, sensor_name, league_id)
+    ht_data = ht_response["ht_data"]
+    url = ht_response["url"]
+
+    if ht_data:
+        raw = (
+            ht_data.get("SiteKit", [{}])
+            .get("Teamsbyseason", [])
+        )
+    else:
+        raw = []
+
+    # Build the teams data
+    teams = []
+    for t in raw:
+        teams.append({
+            "id":            t.get("id", ""),
+            "abbreviation":  t.get("code", ""),
+            "displayName":   t.get("name", ""),
+            "location":      t.get("city", ""),
+            "conference_id": "",
+        })
+    return {"data": teams, "url": url}
+
 
 async def async_fetch_hockeytech_data(
     hass,
@@ -149,7 +246,7 @@ async def async_fetch_hockeytech_data(
         _LOGGER.warning(
             "%s: No HockeyTech config for league '%s'", sensor_name, league_id
         )
-        return None
+        return {"data": None, "url": None}
 
     params = {
         "feed": "modulekit",
@@ -171,7 +268,6 @@ async def async_fetch_hockeytech_data(
         "data": espn_data,
         "url": url
     }
-
 
 def _transform_hockeytech_to_espn(ht_data: dict, league_id: str) -> dict:
     """Transform HockeyTech scorebar data into ESPN-compatible format."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,38 @@ class CustomDirectoryExtension(AmberSnapshotExtension):
 def snapshot(snapshot):
     return snapshot.use_extension(CustomDirectoryExtension)
 
+@pytest.fixture
+async def mock_call_hockeytech_api(hass):
+    """Global fixture to mock the HockeyTech API and return local JSON data."""
+    
+    async def _get_mock_ht_api_data(hass, base_url, params, sensor_name, league_id):
+        """Read FILE_NAME instead of calling the API."""
+
+        if sensor_name == "api_error":
+            return None
+
+        view = params["view"]
+        FILE_NAME = f"tests/tt/hockeytech-{view}.json"
+        url = str(URL(base_url).with_query(params))
+
+        try:
+            with open(FILE_NAME, "r") as f:
+                data = json.load(f)
+            return {
+                "ht_data": data,
+                "url": url,
+            }
+
+        except FileNotFoundError:
+            return {
+                "ht_data": None,
+                "url": url,
+            }
+
+    with patch("custom_components.teamtracker.hockeytech.async_call_hockeytech_api", new_callable=AsyncMock) as mock_ht:
+        mock_ht.side_effect = _get_mock_ht_api_data
+        yield mock_ht
+
 
 @pytest.fixture
 async def mock_call_espn_api(hass):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -288,12 +288,12 @@ async def test_custom_api_team_input(hass):
         await hass.async_block_till_done()
         assert len(mock_setup_entry.mock_calls) == 1
 
-async def test_custom_api_team_list(hass, mock_call_espn_api):
+async def test_custom_api_espn_team_list(hass, mock_call_espn_api):
     """Test the multi-step config flow when team selected from list"""
     #
     # Step 1: Initiate the flow
     # Step 2: Choose "XXX" for Custom API
-    # Step 3: Enter sport_path and league_path
+    # Step 3: Enter sport_path and league_path for ESPN
     # Step 4: Enter team name to search for
     # Step 5: Select team from list
     # Step 6: Input Sensor Name (Override default team name)
@@ -362,6 +362,83 @@ async def test_custom_api_team_list(hass, mock_call_espn_api):
 
         await hass.async_block_till_done()
         assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_custom_api_hockeytech_team_list(hass, mock_call_hockeytech_api):
+    """Test the multi-step config flow when team selected from list"""
+    #
+    # Step 1: Initiate the flow
+    # Step 2: Choose "XXX" for Custom API
+    # Step 3: Enter 'hockeytech' for sport_path and league_path for HockeyTech league
+    # Step 4: Enter team name to search for
+    # Step 5: Select team from list
+    # Step 6: Input Sensor Name (Override default team name)
+    #
+
+    # Step 1: init flow, expect sport selection form
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    # Step 2: choose sport → expect custom_api form
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"sport_key": "XXX"}
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "custom_api"
+
+    # Step 3: enter sport_path and league_path → expect team search form
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {
+                "sport_path": "hockeytech",
+                "league_path": "pwhl",
+            },
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "search"
+
+    # Step 4: enter team search term → expect select_team entry form
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"search_team": "fleet"}
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "select_team"
+
+    # Step 5: select team from list → expect finalize entry form
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"team_selection": "1"} # Must be the team ID from JSON
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "finalize"
+
+    # Step 6: Enter a sensor name to override default (Final Step)
+    with patch(
+        "custom_components.teamtracker.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "name": "Override Sensor Name",    # Override name
+            },
+        )
+
+        assert result["type"] == "create_entry"
+        assert result["title"] == "Override Sensor Name"
+
+        # Verify the data structure matches NCAAF expectations
+        assert result["data"]["league_id"] == "XXX"
+        assert result["data"]["team_id"] == "1"
+        assert result["data"]["sport_path"] == "hockeytech" # Conference ID from the test file as it should be
+        assert result["data"]["league_path"] == "pwhl"
+
+        await hass.async_block_till_done()
+        assert len(mock_setup_entry.mock_calls) == 1
+
 
 async def test_options_flow_init(hass):
     """ Test config flow options """

--- a/tests/test_hockeytech.py
+++ b/tests/test_hockeytech.py
@@ -68,7 +68,8 @@ async def mock_call_hockeytech_api(hass):
         if sensor_name == "api_error":
             return None
 
-        FILE_NAME = "tests/tt/hockeytech-scorebar.json"
+        view = params["view"]
+        FILE_NAME = f"tests/tt/hockeytech-{view}.json"
         url = str(URL(base_url).with_query(params))
 
         try:

--- a/tests/tt/hockeytech-seasons.json
+++ b/tests/tt/hockeytech-seasons.json
@@ -1,0 +1,101 @@
+{
+  "SiteKit": {
+    "Parameters": {
+      "feed": "modulekit",
+      "view": "seasons",
+      "key": "446521baf8c38984",
+      "client_code": "pwhl",
+      "league_id": "1",
+      "season_id": "9"
+    },
+    "Seasons": [
+      {
+        "season_id": "9",
+        "season_name": "2026 Playoffs",
+        "shortname": "2026 Playoffs",
+        "career": "1",
+        "playoff": "1",
+        "start_date": "2026-04-28",
+        "end_date": "2026-05-28"
+      },
+      {
+        "season_id": "8",
+        "season_name": "2025-26 Regular Season",
+        "shortname": "2025-26 Reg",
+        "career": "1",
+        "playoff": "0",
+        "start_date": "2025-11-21",
+        "end_date": "2026-04-27"
+      },
+      {
+        "season_id": "7",
+        "season_name": "2025-26 Preseason",
+        "shortname": "2025-26 Preseason",
+        "career": "0",
+        "playoff": "0",
+        "start_date": "2025-06-01",
+        "end_date": "2025-11-19"
+      },
+      {
+        "season_id": "6",
+        "season_name": "2025 Playoffs",
+        "shortname": "2025 Playoffs",
+        "career": "1",
+        "playoff": "1",
+        "start_date": "2025-05-06",
+        "end_date": "2025-06-03"
+      },
+      {
+        "season_id": "5",
+        "season_name": "2024-25 Regular Season",
+        "shortname": "2024-25 Reg",
+        "career": "1",
+        "playoff": "0",
+        "start_date": "2024-11-25",
+        "end_date": "2025-05-05"
+      },
+      {
+        "season_id": "4",
+        "season_name": "2024-25 Preseason",
+        "shortname": "2024-25 Preseason",
+        "career": "0",
+        "playoff": "0",
+        "start_date": "2024-11-01",
+        "end_date": "2024-11-29"
+      },
+      {
+        "season_id": "3",
+        "season_name": "2024 Playoffs",
+        "shortname": "2024 Playoffs",
+        "career": "1",
+        "playoff": "1",
+        "start_date": "2024-05-06",
+        "end_date": "2024-06-10"
+      },
+      {
+        "season_id": "1",
+        "season_name": "2024 Regular Season",
+        "shortname": "2024 Reg",
+        "career": "1",
+        "playoff": "0",
+        "start_date": "2024-01-01",
+        "end_date": "2024-05-27"
+      },
+      {
+        "season_id": "2",
+        "season_name": "2024 Preseason",
+        "shortname": "2024 Preseason",
+        "career": "0",
+        "playoff": "0",
+        "start_date": "2023-11-01",
+        "end_date": "2023-12-31"
+      }
+    ],
+    "Copyright": {
+      "required_copyright": "Official statistics provided by Professional Women's Hockey League",
+      "required_link": "http://leaguestat.com",
+      "powered_by": "Powered by HockeyTech.com",
+      "powered_by_url": "http://hockeytech.com"
+    }
+  }
+}

--- a/tests/tt/hockeytech-teamsbyseason.json
+++ b/tests/tt/hockeytech-teamsbyseason.json
@@ -1,0 +1,119 @@
+{
+  "SiteKit": {
+    "Parameters": {
+      "feed": "modulekit",
+      "view": "teamsbyseason",
+      "season_id": 8,
+      "key": "446521baf8c38984",
+      "client_code": "pwhl",
+      "lang": "en",
+      "fmt": "json",
+      "lang_id": 1,
+      "league_id": "1"
+    },
+    "Teamsbyseason": [
+      {
+        "id": "1",
+        "name": "Boston Fleet",
+        "city": "Boston",
+        "code": "BOS",
+        "nickname": "Fleet",
+        "team_caption": "",
+        "division_id": "1",
+        "division_long_name": "PWHL",
+        "division_short_name": "PWHL",
+        "team_logo_url": "https://assets.leaguestat.com/pwhl/logos/1.png"
+      },
+      {
+        "id": "2",
+        "name": "Minnesota Frost",
+        "city": "Minnesota",
+        "code": "MIN",
+        "nickname": "Frost",
+        "team_caption": "",
+        "division_id": "1",
+        "division_long_name": "PWHL",
+        "division_short_name": "PWHL",
+        "team_logo_url": "https://assets.leaguestat.com/pwhl/logos/2.jpg"
+      },
+      {
+        "id": "3",
+        "name": "Montréal Victoire",
+        "city": "Montréal",
+        "code": "MTL",
+        "nickname": "Victoire",
+        "team_caption": "",
+        "division_id": "1",
+        "division_long_name": "PWHL",
+        "division_short_name": "PWHL",
+        "team_logo_url": "https://assets.leaguestat.com/pwhl/logos/3.png"
+      },
+      {
+        "id": "4",
+        "name": "New York Sirens",
+        "city": "New York",
+        "code": "NY",
+        "nickname": "Sirens",
+        "team_caption": "",
+        "division_id": "1",
+        "division_long_name": "PWHL",
+        "division_short_name": "PWHL",
+        "team_logo_url": "https://assets.leaguestat.com/pwhl/logos/4.png"
+      },
+      {
+        "id": "5",
+        "name": "Ottawa Charge",
+        "city": "Ottawa",
+        "code": "OTT",
+        "nickname": "Charge",
+        "team_caption": "",
+        "division_id": "1",
+        "division_long_name": "PWHL",
+        "division_short_name": "PWHL",
+        "team_logo_url": "https://assets.leaguestat.com/pwhl/logos/5.png"
+      },
+      {
+        "id": "8",
+        "name": "Seattle Torrent",
+        "city": "Seattle",
+        "code": "SEA",
+        "nickname": "Torrent",
+        "team_caption": "",
+        "division_id": "1",
+        "division_long_name": "PWHL",
+        "division_short_name": "PWHL",
+        "team_logo_url": "https://assets.leaguestat.com/pwhl/logos/8.png"
+      },
+      {
+        "id": "6",
+        "name": "Toronto Sceptres",
+        "city": "Toronto",
+        "code": "TOR",
+        "nickname": "Sceptres",
+        "team_caption": "",
+        "division_id": "1",
+        "division_long_name": "PWHL",
+        "division_short_name": "PWHL",
+        "team_logo_url": "https://assets.leaguestat.com/pwhl/logos/6.png"
+      },
+      {
+        "id": "9",
+        "name": "Vancouver Goldeneyes",
+        "city": "Vancouver",
+        "code": "VAN",
+        "nickname": "Goldeneyes",
+        "team_caption": "",
+        "division_id": "1",
+        "division_long_name": "PWHL",
+        "division_short_name": "PWHL",
+        "team_logo_url": "https://assets.leaguestat.com/pwhl/logos/9.png"
+      }
+    ],
+    "Copyright": {
+      "required_copyright": "Official statistics provided by Professional Women's Hockey League",
+      "required_link": "http://leaguestat.com",
+      "powered_by": "Powered by HockeyTech.com",
+      "powered_by_url": "http://hockeytech.com"
+    }
+  }
+}


### PR DESCRIPTION
**Completed HockeyTech Enhancements and Bug Fixes**
- Improve Config Flow for HockeyTech APIs _(new in beta.2)_
- Expand to all leagues supported by the HockeyTech API
- `api_url` updated to show all parms used
- Enhance testing for hockeytech API (PRE, POST, IN states)
- Change attribution to HockeyTech from ESPN
- Request HockeyTech response in preferred language (only honors fr)
- Reduce refresh rate during IN state for HockeyTech to 60 seconds due to low update rate
- Populate `league_name` for HockeyTech sensors
- Update ESPN api's to HockeyTech model for consistency

**To Do**
- Multiple HockeyTech attributes have Invalid URLs
- Hardcoded URLs do not extend beyond PWHL