### PR TITLE
v0.18.1 Release Candidate

### DIFF
--- a/.github/workflows/hacs_action.yaml
+++ b/.github/workflows/hacs_action.yaml
@@ -18,4 +18,3 @@ jobs:
         uses: "hacs/action@main"
         with:
           category: "integration"
-          ignore: license

--- a/custom_components/teamtracker/const.py
+++ b/custom_components/teamtracker/const.py
@@ -199,7 +199,7 @@ INDIVIDUAL_SPORTS = {"golf", "mma", "tennis"}
 
 # Misc
 TEAM_ID = ""
-VERSION = "v0.18.0"
+VERSION = "v0.18.1"
 ISSUE_URL = "https://github.com/vasqued2/ha-teamtracker"
 DOMAIN = "teamtracker"
 COORDINATOR = "coordinator"

--- a/custom_components/teamtracker/manifest.json
+++ b/custom_components/teamtracker/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/vasqued2/ha-teamtracker/issues",
   "requirements": ["arrow", "aiofiles"],
-  "version": "0.18.0"
+  "version": "0.18.1"
 }

--- a/custom_components/teamtracker/provide_espn.py
+++ b/custom_components/teamtracker/provide_espn.py
@@ -268,7 +268,9 @@ class EspnProvider(BaseSportProvider):
             return {"data": data, "url": url, "timestamp": timestamp}
 
 
-        headers = {"User-Agent": self._USER_AGENT, "Accept": "application/ld+json"}
+        headers = {
+#            "User-Agent": self._USER_AGENT, 
+            "Accept": "application/ld+json"}
         session = async_get_clientsession(hass)
         try:
             async with session.get(url, headers=headers) as r:


### PR DESCRIPTION
- Use Home Assistant as the User Agent for ESPN API calls instead of mocking a `curl` request

Thanks to @kwilson9 for this approach.

**Note**: Originally, TeamTracker mocked a call from a Mozilla browser for ESPN API requests. Many other applications did the same. ESPN began detecting and blocking these mocked requests on Aug. 4th. v0.18.0 got around this block by mocking a call from `curl` instead. v0.18.1 foregoes any mocks and shows the request coming directly from Home Assistant.

ESPN could, at any point, detect and block calls from one or both of these approaches as well.

If in the short term, v0.18.0 stops working, users should first try v0.18.1. If v0.18.1 stops working, users should try reverting to v0.18.0. 

If they both stop working, another coding change will be required. Due to limited developer access, a fix may not be available until after Aug. 20th. See [this issue](https://github.com/vasqued2/ha-teamtracker/issues/354) for detailed information which may contain additional information on how to resolve any new issues directly without waiting for a release.